### PR TITLE
♻️ refactor: refactor login b using next-auth

### DIFF
--- a/src/app/(home)/course/[courseId]/components/course-card.tsx
+++ b/src/app/(home)/course/[courseId]/components/course-card.tsx
@@ -1,4 +1,5 @@
-"use clinet";
+"use client";
+
 import Image from "next/image";
 import React, { useEffect } from "react";
 import {

--- a/src/app/(home)/introduce/page.tsx
+++ b/src/app/(home)/introduce/page.tsx
@@ -33,7 +33,7 @@ export default function IntroducePage() {
 
           <div id="introText">
             <div className="p-16 pr-48 flex flex-row w-full h-auto">
-              <div className="flex w-1/3 m-12">
+              <div className="flex w-[480px] m-12">
                 <Image
                   alt="Profile"
                   className="rounded-lg animate-slide-in"

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -4,8 +4,6 @@ import "../globals.css";
 import { Toaster } from "@/components/ui/toaster";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
-import ReactQueryProviders from "@/components/ReactQueryProvider";
-// import { auth } from "@/auth";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -19,12 +17,11 @@ export default async function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // const session = await auth();
   return (
     <>
       <div className="flex flex-col w-screen min-h-screen">
         <Header />
-        <main className="py-20 overflow-y-auto">{children}</main>
+        <main className="flex-auto py-20 overflow-y-auto">{children}</main>
         <Footer />
       </div>
       <Toaster />

--- a/src/app/(home)/login/page.tsx
+++ b/src/app/(home)/login/page.tsx
@@ -2,7 +2,7 @@ import LoginForm from "./components/LoginForm";
 
 export default function Login() {
   return (
-    <div className="flex flex-col items-center justify-center w-full overflow-y-auto font-medium bg-white font-Pretendard">
+    <div className="flex flex-col p-12 items-center justify-center w-full overflow-y-auto font-medium bg-white font-Pretendard">
       <h3 className="mb-10 text-xl font-bold">로그인</h3>
       <LoginForm />
     </div>

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,68 +1,8 @@
-"use client";
-import { refreshToken } from "@/lib/refreshToken";
 import Image from "next/image";
-import { useEffect, useState } from "react";
-
 import MainBanner from "../../../public/images/main-banner02.jpg";
-import testCoureThumbnail from "../../../public/images/testCourseThumbnail.jpeg";
 import CourseCard from "./course/[courseId]/components/course-card";
 
-interface UserInfo {
-  id: string;
-  name: string;
-  email: string;
-}
-
 export default function Home() {
-  const [userInfo, setUserInfo] = useState<any>();
-  const [accessToken, setAccessToken] = useState<string | null>(null);
-
-  // 사용자 정보 요청 함수 (토큰 만료 시 갱신 로직 포함)
-  async function fetchUserInfo() {
-    if (!accessToken) return; // accessToken이 없으면 함수 실행 중지
-
-    let response;
-    for (let attempt = 0; attempt < 2; attempt++) {
-      response = await fetch("http://localhost:3000/users/profile", {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        setUserInfo(data);
-        return;
-      } else if (response.status === 401) {
-        const newAccessToken = await refreshToken();
-        if (newAccessToken) {
-          setAccessToken(newAccessToken);
-          continue; // 새로운 accessToken으로 다시 시도
-        } else {
-          // 갱신 실패 시 처리
-          return;
-        }
-      } else {
-        // 401이 아닌 다른 오류 처리
-        break;
-      }
-    }
-  }
-
-  // accessToken 초기화
-  useEffect(() => {
-    const token = localStorage.getItem("accessToken");
-    setAccessToken(token);
-  }, []);
-
-  // accessToken이 변경될 때마다 fetchUserInfo 호출
-  useEffect(() => {
-    if (accessToken) {
-      fetchUserInfo().catch(console.error);
-    }
-  }, [accessToken]);
-
   return (
     <main className="flex flex-col h-full">
       <section className="relative w-full h-full">

--- a/src/app/(home)/signup/components/SignupForm.tsx
+++ b/src/app/(home)/signup/components/SignupForm.tsx
@@ -180,7 +180,11 @@ export function InputForm() {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="w-2/5 space-y-6">
+      <form
+        autoComplete="off"
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="w-2/5 space-y-6"
+      >
         <FormField
           control={form.control}
           name="name"
@@ -190,7 +194,11 @@ export function InputForm() {
                 이름 <span className="text-red-500">*</span>
               </FormLabel>
               <FormControl>
-                <Input placeholder="이름을 입력해주세요." {...field} />
+                <Input
+                  autoComplete="off"
+                  placeholder="이름을 입력해주세요."
+                  {...field}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -247,7 +255,11 @@ export function InputForm() {
                 이메일 <span className="text-red-500">*</span>
               </FormLabel>
               <FormControl>
-                <Input placeholder="이메일을 입력해주세요." {...field} />
+                <Input
+                  // autoComplete="off"
+                  placeholder="이메일을 입력해주세요."
+                  {...field}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -262,7 +274,7 @@ export function InputForm() {
                 비밀번호 <span className="text-red-500">*</span>
               </FormLabel>
               <FormControl>
-                <Input type="password" {...field} />
+                <Input autoComplete="new-password" type="password" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -338,9 +350,17 @@ export function InputForm() {
               <FormLabel className="text-base font-bold">
                 부서명 <span className="text-red-500">*</span>
               </FormLabel>
-              <Select {...field} onValueChange={field.onChange}>
+              <Select
+                value={field.value}
+                name={field.name}
+                onValueChange={field.onChange}
+              >
                 <SelectTrigger>
-                  <SelectValue placeholder="부서명 선택" />
+                  <SelectValue
+                    onBlur={field.onBlur}
+                    ref={field.ref}
+                    placeholder="부서명 선택"
+                  />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectGroup>
@@ -365,9 +385,17 @@ export function InputForm() {
               <FormLabel className="text-base font-bold">
                 직분 <span className="text-red-500">*</span>
               </FormLabel>
-              <Select {...field} onValueChange={field.onChange}>
+              <Select
+                value={field.value}
+                name={field.name}
+                onValueChange={field.onChange}
+              >
                 <SelectTrigger>
-                  <SelectValue placeholder="직분 선택" />
+                  <SelectValue
+                    onBlur={field.onBlur}
+                    ref={field.ref}
+                    placeholder="직분 선택"
+                  />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectGroup>

--- a/src/app/(home)/signup/page.tsx
+++ b/src/app/(home)/signup/page.tsx
@@ -2,7 +2,7 @@ import { InputForm } from "./components/SignupForm";
 
 export default function Signup() {
   return (
-    <div className="flex flex-col items-center justify-center w-full overflow-y-auto font-medium bg-white font-Pretendard">
+    <div className="p-10 flex flex-col items-center justify-center w-full overflow-y-auto font-medium bg-white font-Pretendard">
       <h3 className="mb-10 text-xl font-bold">회원가입</h3>
       <InputForm />
     </div>

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/components/LectureHeader.tsx
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/components/LectureHeader.tsx
@@ -11,27 +11,31 @@ import { IProgressResult } from "@/model/progress";
 import { getProgress } from "../lib/getProgress";
 import { usePathname } from "next/navigation";
 import Loading from "../loading";
+import { useSession } from "next-auth/react";
 
 type Props = {
   courseId: number;
   lectureId: number;
 };
 export default function MainHeader({ courseId, lectureId }: Props) {
+  const { data: session } = useSession();
+  const accessToken = session?.user.accessToken;
+
   const lectures = useQuery<Lecture[]>({
     queryKey: ["lectures", courseId],
-    queryFn: () => getLectures(courseId),
+    queryFn: () => getLectures(courseId, accessToken),
+    enabled: !!accessToken,
   });
   const progress = useQuery<IProgressResult>({
     queryKey: ["progress", courseId],
-    queryFn: () => getProgress(courseId),
+    queryFn: () => getProgress(courseId, accessToken),
+    enabled: !!accessToken,
   });
 
   const pathname = usePathname();
 
   const { duration } = useDurationStore((state) => state);
   const seconds = useSecondsStore((state) => state.seconds);
-
-  // console.log(`duration: ${duration}, seconds: ${seconds}`);
 
   if (!lectures.data || !progress.data) {
     return <Loading />;
@@ -56,8 +60,8 @@ export default function MainHeader({ courseId, lectureId }: Props) {
         <div className="absolute right-4">
           {Math.round(seconds / 60)}분/
           {Math.round(duration / 60)}분(
-          {`${Math.floor((seconds / (duration - 1)) * 100)}%`})
-          {/* {`${(Math.floor(seconds / 60) / Math.round(duration / 60)) * 100}%`}) */}
+          {/* {`${Math.floor((seconds / 60 / (duration / 60)) * 100)}%`}) */}
+          {`${(Math.floor(seconds / 60) / Math.round(duration / 60)) * 100}%`})
         </div>
       )}
     </div>

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/components/LectureNav.tsx
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/components/LectureNav.tsx
@@ -26,6 +26,7 @@ import { Course } from "@/model/course";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import Loading from "../loading";
+import { useSession } from "next-auth/react";
 
 type Props = {
   courseId: number;
@@ -33,17 +34,23 @@ type Props = {
 };
 
 export default function LectureNav({ courseId, lectureId }: Props) {
+  const { data: session } = useSession();
+  const accessToken = session?.user.accessToken;
+
   const { data: progress } = useQuery<IProgressResult>({
     queryKey: ["progress", courseId],
-    queryFn: () => getProgress(courseId),
+    queryFn: () => getProgress(courseId, accessToken),
+    enabled: !!accessToken,
   });
   const { data: course } = useQuery<Course>({
     queryKey: ["courses", courseId],
-    queryFn: () => getCourses(courseId),
+    queryFn: () => getCourses(courseId, accessToken),
+    enabled: !!accessToken,
   });
   const { data: lectures } = useQuery<Lecture[]>({
     queryKey: ["lectures", courseId],
-    queryFn: () => getLectures(courseId),
+    queryFn: () => getLectures(courseId, accessToken),
+    enabled: !!accessToken,
   });
   // const { data: quizzes } = useQuery<Lecture[]>({
   //   queryKey: ["quizzes", courseId],

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/components/Sidebar.tsx
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/components/Sidebar.tsx
@@ -1,3 +1,0 @@
-export default function Sidebar() {
-  return <div>d</div>;
-}

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/lib/getCourses.ts
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/lib/getCourses.ts
@@ -1,8 +1,9 @@
-export async function getCourses(courseId: number) {
+export async function getCourses(courseId: number, accessToken: string) {
   const response = await fetch(`http://localhost:3000/courses/${courseId}`, {
     next: {
       tags: ["courses"],
     },
+    headers: { authorization: `Bearer ${accessToken}` },
     credentials: "include",
   });
 

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/lib/getLectures.ts
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/lib/getLectures.ts
@@ -1,10 +1,11 @@
-export async function getLectures(courseId: number) {
+export async function getLectures(courseId: number, accessToken: string) {
   const response = await fetch(
     `http://localhost:3000/courses/${courseId}/lectures`,
     {
       next: {
         tags: ["lectures"],
       },
+      headers: { authorization: `Bearer ${accessToken}` },
       credentials: "include",
     }
   );

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/lib/getProgress.ts
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/lib/getProgress.ts
@@ -1,10 +1,11 @@
-export async function getProgress(courseId: number) {
+export async function getProgress(courseId: number, accessToken: string) {
   const response = await fetch(
-    `http://localhost:3000/courses/${courseId}/lectures/progress?userId=1`,
+    `http://localhost:3000/courses/${courseId}/lectures/progress`,
     {
       next: {
         tags: ["progress"],
       },
+      headers: { authorization: `Bearer ${accessToken}` },
       credentials: "include",
     }
   );

--- a/src/app/api/auth/[...nextAuth]/route.ts
+++ b/src/app/api/auth/[...nextAuth]/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from "@/auth";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import ReactQueryProviders from "@/components/ReactQueryProvider";
-// import AuthSession from "@/components/AuthSession";
+import AuthSession from "@/components/AuthSession";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -19,9 +19,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        {/* <AuthSession> */}
-        <ReactQueryProviders>{children}</ReactQueryProviders>
-        {/* </AuthSession> */}
+        <AuthSession>
+          <ReactQueryProviders>{children}</ReactQueryProviders>
+        </AuthSession>
       </body>
     </html>
   );

--- a/src/app/types/next-auth.d.ts
+++ b/src/app/types/next-auth.d.ts
@@ -1,0 +1,39 @@
+import NextAuth from "next-auth";
+
+// declare module "next-auth" {
+//   interface Session {
+//     user: {
+//       id: number;
+//       name: string;
+//       email: string;
+//       accessToken: string;
+//     };
+//   }
+// }
+
+declare module "next-auth" {
+  /**
+   * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
+   */
+  interface Session {
+    user: {
+      accessToken: any & DefaultSession["user"];
+    };
+    accessToken: string;
+  }
+
+  interface User {
+    accessToken: any & DefaultSession["user"];
+    refreshToken: any & DefaultSession["user"];
+    expiresIn: any & DefaultSession["user"];
+  }
+}
+
+declare module "next-auth/jwt" {
+  /** Returned by the `jwt` callback and `getToken`, when using JWT sessions */
+  interface JWT {
+    /** OpenID ID Token */
+    accessToken?: string;
+    // expiresAt?: string;
+  }
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,99 @@
+import NextAuth from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+
+export const {
+  handlers: { GET, POST },
+  auth,
+  signIn,
+  signOut,
+} = NextAuth({
+  pages: {
+    signIn: "/login",
+    newUser: "/signup",
+  },
+  session: {
+    strategy: "jwt",
+  },
+  callbacks: {
+    // 토큰 관련 action 시 호출되는 Callback
+    async jwt({ token, user }) {
+      if (user) {
+        // Initial Login에만 user가 존재
+        return {
+          ...user,
+          accessToken: user.accessToken,
+          expiresAt: Math.floor(Date.now() / 1000 + user.expiresIn),
+          refreshToken: user.refreshToken,
+        };
+      } else if (Date.now() < (token.expiresAt as number) * 1000) {
+        // 첫 로그인 이후 토큰 access
+        return token;
+      } else {
+        // access token 만료되어 토큰 재발급
+        console.log("=========== access token 만료 토큰 재발급 ===========");
+        try {
+          const response = await fetch(
+            `${process.env.NEXT_PUBLIC_BASE_URL}/auth/refresh-token`,
+            {
+              method: "GET",
+              headers: {
+                "Content-Type": "application/json",
+                Cookie: `refreshToken=${token.refreshToken}`,
+              },
+              credentials: "include",
+            }
+          );
+          const newTokens = await response.json();
+
+          if (!response.ok) throw newTokens.accessToken;
+
+          return {
+            ...token,
+            accessToken: newTokens.accessToken,
+            expiresAt: Math.floor(Date.now() / 1000 + newTokens.expiresIn),
+            // refreshToken: newTokens.refresh_token ?? token.refresh_token,
+          };
+        } catch (error) {
+          console.error("Error refreshing access token", error);
+          return { ...token, error: "RefreshAccessTokenError" as const };
+        }
+      }
+    },
+    // Session 관련 action 시 호출되는 callback
+    session({ session, token }) {
+      session.user = token as any;
+      return session;
+    },
+  },
+
+  providers: [
+    CredentialsProvider({
+      async authorize(credentials) {
+        // signIn 호출 시 동작
+        const authResponse = await fetch(
+          `${process.env.NEXT_PUBLIC_BASE_URL}/auth/sign-in`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              nameBirthId: credentials.nameBirthId,
+              password: credentials.password,
+            }),
+            credentials: "include",
+          }
+        );
+
+        if (!authResponse.ok) {
+          console.log("return null");
+          return null;
+        }
+
+        const user = await authResponse.json();
+        console.log("user", user);
+        return user;
+      },
+    }),
+  ],
+});

--- a/src/components/AuthSession.tsx
+++ b/src/components/AuthSession.tsx
@@ -1,10 +1,10 @@
-// "use client";
-// import { SessionProvider } from "next-auth/react";
+"use client";
+import { SessionProvider } from "next-auth/react";
 
-// type Props = {
-//   children: React.ReactNode;
-// };
+type Props = {
+  children: React.ReactNode;
+};
 
-// export default function AuthSession({ children }: Props) {
-//   return <SessionProvider>{children}</SessionProvider>;
-// }
+export default function AuthSession({ children }: Props) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,26 +1,20 @@
 "use client";
-import Image from "next/image";
-// import logo from "../../../public/images/logo_black.png";
-import { useEffect, useState } from "react";
-import { useAuthStore } from "@/store/useAuthStore";
-import { useLoginStatus } from "@/hooks/useLoginStatus";
 
+import Image from "next/image";
+import { useState } from "react";
 import { IoMenu } from "react-icons/io5";
 import Link from "next/link";
+import { signOut, useSession } from "next-auth/react";
 
 export default function Header() {
-  const [accessToken, setAccessToken] = useState<string | null>(null);
   const [isOpen, setIsOpen] = useState(false);
 
-  function Logout() {
-    localStorage.removeItem("accessToken");
-    setAccessToken(null);
-  }
-  // accessToken 초기화
-  useEffect(() => {
-    const token = localStorage.getItem("accessToken");
-    setAccessToken(token);
-  }, [accessToken]);
+  const { data: session } = useSession();
+
+  // TODO: 렌더링이 왤케 많이 되지?
+  // useEffect(() => {
+  //   console.log(session);
+  // }, [session]);
 
   return (
     <header className="fixed inset-x-0 top-0 left-0 z-50 text-gray-700 bg-white border-b border-gray-200 font-Pretendard">
@@ -59,7 +53,7 @@ export default function Header() {
                 >
                   강의 목록
                 </Link>
-                {accessToken ? (
+                {session ? (
                   <>
                     <Link
                       className="w-full text-left hover:text-blue-900"
@@ -76,7 +70,9 @@ export default function Header() {
                     <Link
                       className="w-full text-left hover:text-blue-900"
                       href="/"
-                      onClick={Logout}
+                      onClick={() => {
+                        signOut();
+                      }}
                     >
                       로그아웃
                     </Link>
@@ -108,7 +104,7 @@ export default function Header() {
           <Link className="mr-5 hover:text-blue-900" href="/course">
             강의목록
           </Link>
-          {accessToken ? (
+          {session ? (
             <>
               <Link className="mr-5 hover:text-blue-900" href="#">
                 내 강의실
@@ -119,7 +115,9 @@ export default function Header() {
               <Link
                 className="mr-5 hover:text-blue-900"
                 href="/"
-                onClick={Logout}
+                onClick={() => {
+                  signOut();
+                }}
               >
                 로그아웃
               </Link>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,14 @@
+import { auth } from "./auth";
+import { NextResponse } from "next/server";
+
+export async function middleware() {
+  const session = await auth();
+  if (!session) {
+    return NextResponse.redirect("http://localhost:3001/login");
+  }
+}
+
+// See "Matching Paths" below to learn more
+export const config = {
+  matcher: ["/course"],
+};


### PR DESCRIPTION
### 📟 연결된 이슈
#20 


### 👷 작업한 내용
- 기존에 사용하던 localStorage 기반 로그인 방식은 클라이언트에서만 세션에 접근 가능하고 로그인 시 헤더의 정보가 새로고침 후에 변경되는 문제가 있었음
- next-auth 라이브러리를 사용한 아이디+비밀번호 기반 로그인 기능 구현
- next-auth login flow
  - /login 페이지 진입
  - 아이디+비밀번호 입력 후 버튼 클릭
  - next-auth의 signIn 함수 호출
  - auth.ts의 authorize() 실행
  - 세션+토큰 생성
  - '/'으로 리다이렉트
- token management
  - 서버로부터 access token과 refresh token을 받아 token에 저장하고 토큰에 접근할 때마다 jwt 콜백이 실행된다.
  - 해당 콜백에서는 기존의 token을 가져오되 유효기간을 검사하여 만료된 경우 refresh-token 쿠키에 담아 API를 호출하여 새로 받은 access token을 다시 저장 및 반환하도록 한다.
- 세션 사용방법
  - client component(recommended): `const {data: session} = useSession()`
  - server component: `const session = await auth();`
  - 사용: `{session ? ... : ...}`
- middleware
  - route 경로를 session 유무에 따라 보호하는 기능
  - session이 없다면 /login으로 리다이렉트 됨
- react-query와 같이 사용
```
  const lectures = useQuery<Lecture[]>({
    queryKey: ["lectures", courseId],
    queryFn: () => getLectures(courseId),
    queryFn: () => getLectures(courseId, accessToken),
    enabled: !!accessToken,
  });
```
enabled 속성을 주면 false일 때 쿼리를 실행하지 않는데 accessToken 유무를 해당 속성의 값으로 주어 accessToken이 존재할 때만 쿼리를 실행하여 불필요한 API 요청이 없도록 함.(!!accessToken -> accessToken 값이 있으면 true, 없으면 false와 같이 boolean으로 만들어주는 문법)


### 📸 스크린샷
