### PR TITLE
Feat/quiz

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nodelib/fs.scandir": "^3.0.0",
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-alert-dialog": "^1.0.5",
+        "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-progress": "^1.0.3",
@@ -637,6 +638,36 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.0.4.tgz",
+      "integrity": "sha512-CBuGQa52aAYnADZVt/KBQzXrwx6TqnlwtcIPGtVt5JkkzQwMOLJjPukimhfKEr4GQNd43C+djUh5Ikopj8pSLg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-use-size": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@nodelib/fs.scandir": "^3.0.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.5",
+    "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-progress": "^1.0.3",

--- a/src/app/(home)/course/[courseId]/components/course-card.tsx
+++ b/src/app/(home)/course/[courseId]/components/course-card.tsx
@@ -60,15 +60,16 @@ const CourseCard: React.FC = ({}) => {
             priority
           />
           <div className="p-4 text-lg ">{ele.title}</div>
-
-          <button
-            className="w-full px-4 py-2 text-blue-600 transition-colors duration-150 bg-white border border-blue-600 rounded-xl hover:bg-blue-600 hover:text-white"
-            onClick={() => {
-              router.push(`/course/${ele.courseId}`);
-            }}
-          >
-            강의 들으러 가기
-          </button>
+          <div className="py-2">
+            <button
+              className="w-full px-4 py-2 text-blue-600 transition-colors duration-150 bg-white border border-blue-600 rounded-xl hover:bg-blue-600 hover:text-white"
+              onClick={() => {
+                router.push(`/course/${ele.courseId}`);
+              }}
+            >
+              강의 들으러 가기
+            </button>
+          </div>
         </div>
       ))}
     </>

--- a/src/app/(home)/course/[courseId]/components/lecture-list.tsx
+++ b/src/app/(home)/course/[courseId]/components/lecture-list.tsx
@@ -4,34 +4,55 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import Link from "next/link";
 import { FaCirclePlay } from "react-icons/fa6";
 import { MdOutlineQuiz } from "react-icons/md";
 
-export default function LectureList() {
+type Lecture = {
+  lectureId: number;
+  courseId: number;
+  lectureNumber: number;
+  title: string;
+  videoLink: string;
+  attachmentFile: string | null; // Assuming it can be null since other examples have it as null
+  status: "active"; // This can be expanded if there are more statuses
+  createdAt: string;
+  updatedAt: string;
+  quizzes: any[]; // Define more specifically if you have a structure for quizzes
+  lectureTimeRecords: any[]; // Define more specifically if you have a structure for lectureTimeRecords
+};
+
+export default function LectureList({ lectures }: Lecture) {
   return (
     <Accordion type="single" collapsible className="w-full">
-      <AccordionItem
-        value={`item-${1}`}
-        className="bg-blue-100 border border-blue-300 rounded-md "
-      >
-        <AccordionTrigger className="mx-4 text-xl ">
-          1강 제목이 들어갈 공간입니다.
-        </AccordionTrigger>
+      {lectures?.map((ele: Lecture, index: number) => (
+        <AccordionItem
+          key={ele.lectureId}
+          value={`item-${index}`}
+          className="bg-blue-100 border border-blue-300 rounded-md mt-3"
+        >
+          <AccordionTrigger className="mx-4 text-xl ">
+            {ele.lectureNumber}강 {ele.title}
+          </AccordionTrigger>
 
-        <AccordionContent className="flex items-center p-2 bg-white">
-          <FaCirclePlay className="mr-2" size={16} />
-          <p>1강 링크가 들어갈 곳이고요</p>
-        </AccordionContent>
+          <AccordionContent className="flex items-center p-2 bg-white">
+            <FaCirclePlay className="mr-2" size={16} />
+            <Link href={`/course/${ele.courseId}/lecture/${ele.lectureId}`}>
+              강의 들으러 가기
+            </Link>
+          </AccordionContent>
 
-        <AccordionContent className="flex items-center p-2 bg-white">
-          <MdOutlineQuiz className="mr-2" size={16} />
-          <p>1강 퀴즈</p>
-        </AccordionContent>
-        <AccordionContent className="flex items-center p-2 bg-white">
-          <MdOutlineQuiz className="mr-2" size={16} />
-          <p>1강 퀴즈</p>
-        </AccordionContent>
-      </AccordionItem>
+          <AccordionContent className="flex items-center p-2 bg-white">
+            <MdOutlineQuiz className="mr-2" size={16} />
+            <p>1강 퀴즈</p>
+          </AccordionContent>
+
+          <AccordionContent className="flex items-center p-2 bg-white">
+            <MdOutlineQuiz className="mr-2" size={16} />
+            <p>1강 퀴즈</p>
+          </AccordionContent>
+        </AccordionItem>
+      ))}
     </Accordion>
   );
 }

--- a/src/app/(home)/course/[courseId]/page.tsx
+++ b/src/app/(home)/course/[courseId]/page.tsx
@@ -1,10 +1,14 @@
 "use client";
 import Image from "next/image";
 import testCoureThumbnail from "../../../../../public/images/testCourseThumbnail.jpeg";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Progress } from "@/components/ui/progress";
 import LectureList from "@/app/(home)/course/[courseId]/components/lecture-list";
+import { getLectures } from "../../../(lecture)/course/[courseId]/lecture/[lectureId]/lib/getLectures";
+import { Lecture } from "@/model/lecture";
+import { useSession } from "next-auth/react";
+import Loading from "@/app/(lecture)/course/[courseId]/lecture/[lectureId]/loading";
 
 function createMarkup(text: string) {
   const paragraphs = text.split("\n\n");
@@ -18,12 +22,14 @@ function createMarkup(text: string) {
 export default function CourseDetailPage({
   params: { courseId },
 }: {
-  params: { courseId: string };
+  params: { courseId: number };
 }) {
-  console.log(courseId);
+  // console.log(courseId);
 
   const [isShown, setIsShown] = useState<number>(1);
   const [isTaking, setIsTaking] = useState<boolean>(true);
+  const { data: session } = useSession();
+  const accessToken = session?.user.accessToken;
 
   // nav 바 메뉴 클릭시 작동 여부
   const handleClick = (ele: number) => {
@@ -38,9 +44,24 @@ export default function CourseDetailPage({
       }),
   });
 
-  console.log(data);
+  // const lectures = useQuery<Lecture[]>({
+  //   queryKey: ["lectures", courseId],
+  //   queryFn: () => getLectures(courseId, accessToken),
+  //   enabled: !!accessToken,
+  // });
 
-  if (isPending) return "로딩 중...";
+  const { data: lectures } = useQuery<Lecture[]>({
+    queryKey: ["lectures", courseId],
+    queryFn: () => getLectures(courseId, accessToken),
+    enabled: !!accessToken,
+  });
+
+  console.log("data");
+  console.log(data);
+  console.log("lectures");
+  console.log(lectures);
+
+  if (isPending) return <Loading />;
 
   if (error) return "An error has occurred: " + error.message;
 
@@ -143,7 +164,7 @@ export default function CourseDetailPage({
               <h1 className="font-mono text-2xl font-bold">강의 목록</h1>
             </div>
             <div className="w-full h-auto mt-4 ">
-              <LectureList />
+              <LectureList lectures={lectures} />
             </div>
           </div>
           <div className="flex items-start flex-auto w-5/12 p-6 ">

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/components/LectureHeader.tsx
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/components/LectureHeader.tsx
@@ -60,8 +60,8 @@ export default function MainHeader({ courseId, lectureId }: Props) {
         <div className="absolute right-4">
           {Math.round(seconds / 60)}분/
           {Math.round(duration / 60)}분(
-          {/* {`${Math.floor((seconds / 60 / (duration / 60)) * 100)}%`}) */}
-          {`${(Math.floor(seconds / 60) / Math.round(duration / 60)) * 100}%`})
+          {`${Math.floor((seconds / 60 / (duration / 60)) * 100)}%`})
+          {/* {`${(Math.floor(seconds / 60) / Math.round(duration / 60)) * 100}%`}) */}
         </div>
       )}
     </div>

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/layout.tsx
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/layout.tsx
@@ -8,6 +8,9 @@ import LectureNav from "./components/LectureNav";
 import { getLectures } from "./lib/getLectures";
 import { getProgress } from "./lib/getProgress";
 import { getCourses } from "./lib/getCourses";
+import { Toast } from "@/components/ui/toast";
+import { useSession } from "next-auth/react";
+import { auth } from "@/auth";
 
 type Props = {
   params: { courseId: number; lectureId: number };
@@ -15,19 +18,21 @@ type Props = {
 };
 export default async function LectureLayout({ children, params }: Props) {
   const { courseId, lectureId } = params;
+  const session = await auth();
+  const accessToken = session?.user.accessToken as string;
 
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({
     queryKey: ["lectures", courseId],
-    queryFn: () => getLectures(courseId),
+    queryFn: () => getLectures(courseId, accessToken),
   });
   await queryClient.prefetchQuery({
     queryKey: ["progress", courseId],
-    queryFn: () => getProgress(courseId),
+    queryFn: () => getProgress(courseId, accessToken),
   });
   await queryClient.prefetchQuery({
     queryKey: ["courses", courseId],
-    queryFn: () => getCourses(courseId),
+    queryFn: () => getCourses(courseId, accessToken),
   });
   const dehydratedState = dehydrate(queryClient);
 

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/lib/getQuiz.ts
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/lib/getQuiz.ts
@@ -1,10 +1,19 @@
-export async function getQuiz(courseId: number) {
-  const response = await fetch(`http://localhost:3000/quizzes/${courseId}`, {
-    next: {
-      tags: ["quizzes"],
-    },
-    credentials: "include",
-  });
+export async function getQuiz(
+  courseId: number,
+  lectureId: number,
+  accessToken: string
+) {
+  // const response = await fetch(`http://localhost:3000/quizzes/${courseId}`, {
+  const response = await fetch(
+    `http://localhost:3000/quizzes/${courseId}/${lectureId}`,
+    {
+      next: {
+        tags: ["quizzes"],
+      },
+      headers: { authorization: `Bearer ${accessToken}` },
+      credentials: "include",
+    }
+  );
 
   if (!response.ok) {
     throw new Error("Failed to get lectures");
@@ -12,3 +21,5 @@ export async function getQuiz(courseId: number) {
 
   return response.json();
 }
+
+// http://localhost:3000/quizzes/:courseId/:lectureId

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/multiple/page.tsx
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/multiple/page.tsx
@@ -1,8 +1,209 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { QueryClient, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getQuiz } from "../lib/getQuiz";
+import { Quiz } from "@/model/quiz";
+import Loading from "../loading";
+import { useEffect, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { toast } from "@/components/ui/use-toast";
+import { useSession } from "next-auth/react";
+import { Lecture } from "@/model/lecture";
+import { getLectures } from "../lib/getLectures";
+
+// 답변 선택 유효성 검사 스키마 정의
+const FormSchema = z.object({
+  items: z
+    .array(z.number())
+    .min(1, { message: "한 개 이상의 답안을 선택 후 제출해주세요." }),
+});
+
 export default function Multiple() {
+  // reactHook 모음
+  const router = useRouter();
+  const params = useParams();
+  const [selectedAnswers, setSelectedAnswers] = useState<number[]>([]);
+  const { data: session } = useSession();
+  const accessToken = session?.user.accessToken as string;
+  const searchParams = useSearchParams();
+  const [queryClient] = useState(() => new QueryClient());
+
+  const search = parseInt(searchParams.get("quizIndex") as string);
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm<z.infer<typeof FormSchema>>({
+    resolver: zodResolver(FormSchema),
+  });
+
+  // 선택된 답변을 form에 반영
+  useEffect(() => {
+    setValue("items", selectedAnswers);
+  }, [selectedAnswers, setValue]);
+
+  // 단항 덧셈 연산자를 사용하여 문자열을 숫자로 변환
+  const courseId = +params.courseId;
+  const lectureId = +params.lectureId;
+
+  // 퀴즈 데이터 받아오기
+  const { data: quizzes } = useQuery<Quiz[]>({
+    queryKey: ["quizzes", courseId, lectureId],
+    queryFn: () => getQuiz(courseId, lectureId, accessToken),
+    enabled: !!accessToken,
+  });
+
+  // 퀴즈 데이터를 완전히 불러올 때까지 로딩
+  if (!quizzes) {
+    return <Loading />;
+  }
+
+  // 객관식 itemIndex 별로 오름차순 정렬
+  quizzes[search - 1].quizAnswers.sort((a, b) => a.itemIndex - b.itemIndex);
+
+  // 정답이 여러 개 있는지 확인
+  const isMultipleAnswers =
+    quizzes[search - 1].quizAnswers.filter((a) => a.isAnswer).length > 1;
+
+  // 현재 사용자가 제출하지 않은 퀴즈가 남아있는지 확인
+  const nextQuiz = quizzes.filter((ele) => {
+    return ele.quizSubmits.length === 0 && search !== ele.quizIndex;
+  });
+
+  // 정답이 여러 개 있는지 확인(isMultipleAnswer)에 따라 객관식 선택이 다양해짐
+  const handleAnswerSelection = (itemIndex: number) => {
+    if (isMultipleAnswers) {
+      // 여러 개의 정답을 선택할 수 있음
+      setSelectedAnswers((prev) =>
+        prev.includes(itemIndex)
+          ? prev.filter((index) => index !== itemIndex)
+          : [...prev, itemIndex]
+      );
+    } else {
+      // 오직 하나의 정답만 선택할 수 있음
+      setSelectedAnswers([itemIndex]);
+    }
+  };
+
+  //! 퀴즈 제출 버튼을 클릭했을 때 동작
+  const onSubmit = async (data: z.infer<typeof FormSchema>) => {
+    // 보낼 데이터 묶음
+    const sendData = {
+      quizId: quizzes[search - 1].quizId,
+      multipleAnswer: data.items,
+    };
+
+    // quizSubmits에 저장
+    const response = await fetch(
+      `http://localhost:3000/quizzes/${courseId}/${lectureId}`,
+      {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify(sendData),
+      }
+    );
+    if (response.ok) {
+      // 서버로부터 성공적인 응답을 받았을 때
+
+      toast({
+        title: "답변 제출을 완료 했습니다.",
+        duration: 10000,
+        description: (
+          <div className="flex justify-end mt-2 w-[340px] rounded-md p-4">
+            {/* 남아있는 퀴즈가 있을 경우 남은 퀴즈로 이동 */}
+            {nextQuiz.length > 0 ? (
+              <Button
+                className="shadow-md bg-blue-500 text-white hover:bg-slate-50 hover:text-black"
+                onClick={() => {
+                  router.push(
+                    `/course/${courseId}/lecture/${lectureId}/${nextQuiz[0].quizType}?quizIndex=${nextQuiz[0].quizIndex}`
+                  );
+                }}
+              >
+                다음 퀴즈로 이동
+              </Button>
+            ) : (
+              // 아닐 경우 다음 강의로 이동
+              <Button
+                className="shadow-md bg-blue-500 text-white hover:bg-slate-50 hover:text-black"
+                onClick={() => {
+                  router.push(`/course/${courseId}/lecture/${lectureId + 1}`);
+                }}
+              >
+                다음 강의로 이동
+              </Button>
+            )}
+          </div>
+        ),
+      });
+      // 만약 퀴즈 제출이 중복이거나 실패할 경우
+    } else if (response.status === 400) {
+      const message = await response.json();
+      // 오류 처리
+      toast({
+        title: message.message,
+        variant: "destructive",
+        duration: 3000,
+      });
+    } else {
+      toast({
+        title: "답변 제출에 실패했습니다.",
+        variant: "destructive",
+        duration: 3000,
+      });
+    }
+  };
+
   return (
-    <div className="flex flex-col mt-10 items-center h-full space-y-4">
-      <h1 className="text-2xl">객관식 퀴즈</h1>
-      <h2>꼼꼼 Check! 헷갈리는 부분이 없는지 확인해보아요.</h2>
-    </div>
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
+      <div className="flex flex-col mt-10 items-center h-full space-y-4">
+        <h1 className="text-2xl">과제</h1>
+        <h2>꼼꼼 Check! - 헷갈리는 부분이 없는지 확인해보아요.</h2>
+
+        <Card className="w-full h-3/4 p-4 pt-10 mx-auto">
+          <CardContent className="flex flex-col gap-4">
+            <CardHeader className="flex flex-col gap-1">
+              {quizzes[search - 1].quizType === "multiple" ? (
+                <div>객관식 퀴즈</div>
+              ) : (
+                <div>설문</div>
+              )}
+
+              <div className="text-sm leading-none">{quizzes[0].question}</div>
+            </CardHeader>
+
+            {quizzes[search - 1].quizAnswers.map((answer) => (
+              <div key={answer.itemIndex} className="flex items-center gap-4">
+                <Checkbox
+                  {...register("items")}
+                  checked={selectedAnswers.includes(answer.itemIndex)}
+                  onCheckedChange={() =>
+                    handleAnswerSelection(answer.itemIndex)
+                  }
+                />
+                <span className="font-medium">{answer.item}</span>
+              </div>
+            ))}
+            {errors.items && (
+              <p className="text-red-600">{errors.items.message}</p>
+            )}
+
+            <Button type="submit">답변 제출</Button>
+          </CardContent>
+        </Card>
+      </div>
+    </form>
   );
 }

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/page.tsx
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/page.tsx
@@ -6,6 +6,7 @@ import {
 import LectureVideo from "./components/LectureVideo";
 import { getLectures } from "./lib/getLectures";
 import { getProgress } from "./lib/getProgress";
+import { auth } from "@/auth";
 
 type Props = {
   params: { lectureId: number; courseId: number };
@@ -13,17 +14,20 @@ type Props = {
 
 export default async function Page({ params }: Props) {
   const { lectureId, courseId } = params;
-
+  const session = await auth();
+  const accessToken = session?.user.accessToken as string;
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({
     queryKey: ["lectures", courseId],
-    queryFn: () => getLectures(courseId),
+    queryFn: () => getLectures(courseId, accessToken),
   });
   await queryClient.prefetchQuery({
     queryKey: ["progress", courseId],
-    queryFn: () => getProgress(courseId),
+    queryFn: () => getProgress(courseId, accessToken),
   });
   const dehydratedState = dehydrate(queryClient);
+
+  console.log(session);
 
   return (
     <HydrationBoundary state={dehydratedState}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import ReactQueryProviders from "@/components/ReactQueryProvider";
 import AuthSession from "@/components/AuthSession";
+import { Toaster } from "@/components/ui/toaster";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -22,6 +23,7 @@ export default function RootLayout({
         <AuthSession>
           <ReactQueryProviders>{children}</ReactQueryProviders>
         </AuthSession>
+        <Toaster />
       </body>
     </html>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -71,7 +71,7 @@ export default function Header() {
                       className="w-full text-left hover:text-blue-900"
                       href="/"
                       onClick={() => {
-                        signOut();
+                        signOut({ callbackUrl: "/" });
                       }}
                     >
                       로그아웃
@@ -116,7 +116,7 @@ export default function Header() {
                 className="mr-5 hover:text-blue-900"
                 href="/"
                 onClick={() => {
-                  signOut();
+                  signOut({ callbackUrl: "/" });
                 }}
               >
                 로그아웃

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/src/model/quiz.ts
+++ b/src/model/quiz.ts
@@ -1,10 +1,33 @@
+interface QuizAnswer {
+  id: number;
+  itemIndex: number;
+  quizId: number;
+  item: string;
+  isAnswer: boolean;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface QuizSubmit {
+  id: number;
+  userId: number;
+  multipleAnswer: number;
+  submittedAnswer: string | null;
+  feedbackComment: string | null;
+  status: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface Quiz {
   quizId: number;
   quizType: string;
   quizIndex: number;
+  quizAnswers: QuizAnswer[];
   question: string;
   status: string;
   createdAt: string;
   updatedAt: string;
-  // quizSubmits: QuizSubmit[]
+  quizSubmits: QuizSubmit[];
 }


### PR DESCRIPTION
### 📟 연결된 이슈
#19 
.

### 👷 작업한 내용
- [ ] 객관식 퀴즈 페이지 생성
- [ ] 객관식 퀴즈 정보를 받을 때 복수 정답 가능인지 아닌지에 따라 정답 선택 개수가 달라지는 기능 구현
- [ ] 강의를 완료하지 않으면 퀴즈로 이동할 수 없도록 구현(toast 메세지 추가)
- [ ] 퀴즈 제출 후 BE를 통해 DB에 QuizSubmits에 저장되도록 구현
- [ ] 퀴즈 제출 후, 여러 퀴즈 문제 중, 완료하지 않은 문제로 이동하는 기능 구현
- [ ] 퀴즈 제출 후 페이지 리렌더링 시에 옆에 완료 표시 되도록 구현 (이 기능은 추후 보완 예정) #27 
- [ ] 그 외 기타 자잘한 기능 및 버그 fix
.

### 📸 스크린샷
![image](https://github.com/FG-Academy/FG-Academy-FE/assets/66247589/dbe913fc-1cbb-4bef-8247-13b1f5d7ef2d)
![image](https://github.com/FG-Academy/FG-Academy-FE/assets/66247589/ba4c9e38-d1d6-4d59-9051-e0c735e308c7)
