### PR TITLE
refactor: 클라이언트 요구사항 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nodelib/fs.scandir": "^3.0.0",
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-alert-dialog": "^1.0.5",
+        "@radix-ui/react-aspect-ratio": "^1.0.3",
         "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-dialog": "^1.0.5",
@@ -1089,6 +1090,29 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz",
       "integrity": "sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.0.3.tgz",
+      "integrity": "sha512-fXR5kbMan9oQqMuacfzlGG/SQMcmMlZ4wrvpckv8SgUulD0MMpspxJrxg/Gp/ISV3JfV1AeSWTYK9GvxA4ySwA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@nodelib/fs.scandir": "^3.0.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.5",
+    "@radix-ui/react-aspect-ratio": "^1.0.3",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/src/app/(admin)/admin/components/SideNav.tsx
+++ b/src/app/(admin)/admin/components/SideNav.tsx
@@ -3,11 +3,15 @@
 import { Users } from "lucide-react";
 import { Video } from "lucide-react";
 import { MessageCircleQuestion } from "lucide-react";
+import { useSession } from "next-auth/react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 export default function SideNav() {
+  const { data: session } = useSession();
+  const userLevel = session?.user.level;
+
   const pathname = usePathname();
   const linkClassName = (linkType: string) => {
     const isActivePage = pathname.includes(linkType);
@@ -29,7 +33,7 @@ export default function SideNav() {
 
   return (
     // h-screen 뺌
-    <div className="w-auto flex-1">
+    <div className="w-auto">
       <div className="w-[300px] h-full bg-blue-700 text-white flex flex-col items-center">
         <Link
           href="/"
@@ -48,52 +52,67 @@ export default function SideNav() {
           />
         </Link>
         <nav className="flex flex-col items-start justify-center w-full">
-          <Link href="/admin/users" className={linkClassName("users")}>
-            <Users />
-            <div>유저 관리</div>
-          </Link>
+          {userLevel === "tutor" ? (
+            <Link
+              href="/admin/quizzes"
+              className={`flex flex-col ${linkClassName("quizzes")}`}
+            >
+              <div className="flex flex-row space-x-2">
+                <MessageCircleQuestion />
+                <div>퀴즈 관리</div>
+              </div>
+            </Link>
+          ) : (
+            <>
+              <Link href="/admin/users" className={linkClassName("users")}>
+                <Users />
+                <div>유저 관리</div>
+              </Link>
 
-          <Link href="/admin/videos" className={linkClassName("videos")}>
-            <Video />
-            <div>강의 관리</div>
-          </Link>
-          <Link
-            href="/admin/quizzes"
-            className={`flex flex-col ${linkClassName("quizzes")}`}
-          >
-            <div className="flex flex-row space-x-2">
-              <MessageCircleQuestion />
-              <div>퀴즈 관리</div>
-            </div>
-          </Link>
-          <div className="w-full flex flex-col px-4 mt-2">
-            <ul className="list-disc pl-5">
-              <li>
-                <Link
-                  className={`${sublinkClassName("quizzes/multiple")}`}
-                  href="/admin/quizzes/multiple"
-                >
-                  객관식 퀴즈 현황
-                </Link>
-              </li>
-              <li>
-                <Link
-                  className={`${sublinkClassName("quizzes/descriptive")}`}
-                  href="/admin/quizzes/descriptive"
-                >
-                  주관식 퀴즈 관리
-                </Link>
-              </li>
-              <li>
-                <Link
-                  className={`${sublinkClassName("quizzes/register")}`}
-                  href="/admin/quizzes/register"
-                >
-                  퀴즈 등록
-                </Link>
-              </li>
-            </ul>
-          </div>
+              <Link href="/admin/videos" className={linkClassName("videos")}>
+                <Video />
+                <div>강의 관리</div>
+              </Link>
+
+              <Link
+                href="/admin/quizzes"
+                className={`flex flex-col ${linkClassName("quizzes")}`}
+              >
+                <div className="flex flex-row space-x-2">
+                  <MessageCircleQuestion />
+                  <div>퀴즈 관리</div>
+                </div>
+              </Link>
+              <div className="w-full flex flex-col px-4 mt-2">
+                <ul className="list-disc pl-5">
+                  {/* <li>
+                    <Link
+                      className={`${sublinkClassName("quizzes/multiple")}`}
+                      href="/admin/quizzes/multiple"
+                    >
+                      객관식 퀴즈 현황
+                    </Link>
+                  </li> */}
+                  <li>
+                    <Link
+                      className={`${sublinkClassName("quizzes/descriptive")}`}
+                      href="/admin/quizzes/descriptive"
+                    >
+                      퀴즈 관리
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      className={`${sublinkClassName("quizzes/register")}`}
+                      href="/admin/quizzes/register"
+                    >
+                      퀴즈 등록
+                    </Link>
+                  </li>
+                </ul>
+              </div>
+            </>
+          )}
         </nav>
       </div>
     </div>

--- a/src/app/(admin)/admin/components/SortingHeader.tsx
+++ b/src/app/(admin)/admin/components/SortingHeader.tsx
@@ -33,13 +33,15 @@ export function SortingHeader<TData, TValue>({
   }
 
   return (
-    <Button
-      className="w-full"
-      variant="ghost"
-      onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-    >
-      {title}
-      <ArrowUpDown className="ml-2 h-4 w-4" />
-    </Button>
+    <div className="w-full items-start">
+      <Button
+        className=""
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        {title}
+        <ArrowUpDown className="ml-2 h-4 w-4" />
+      </Button>
+    </div>
   );
 }

--- a/src/app/(admin)/admin/hooks/useAdminCourseQuery.ts
+++ b/src/app/(admin)/admin/hooks/useAdminCourseQuery.ts
@@ -8,6 +8,8 @@ import { IEnrollment } from "@/model/enrollment";
 export interface AdminCoursesResponse extends ICourse {
   enrollments: IEnrollment[];
   enrollmentCount: number;
+  multipleCount: number;
+  descriptiveCount: number;
 }
 
 export interface AdminCourseReponse extends ICourse {

--- a/src/app/(admin)/admin/hooks/useUserQuery.ts
+++ b/src/app/(admin)/admin/hooks/useUserQuery.ts
@@ -3,16 +3,36 @@ import { getAllUsers } from "../lib/getAllUsers";
 import { getOneUser } from "../lib/getOneUser";
 import { IUser } from "@/model/user";
 import getAdminSubmittedQuizList from "../lib/getAdminSubmittedQuizList";
+import { IQuizAnswer } from "@/model/quiz";
 
-interface Course {
-  courseId: number;
-  title: string;
+interface Quiz {
+  quizId: number;
+  quizAnswers: IQuizAnswer[];
+  quizType: string;
+  question: string;
+  answer: number[];
+  submitCount: number;
+  correctCount: number;
+  answerType: string;
 }
-
+interface Lecture {
+  lectureNumber: number;
+  lectureId: number;
+  lectureTitle: string;
+  quizzes: Quiz[];
+  quizTotalCount: number;
+  correctQuizCount: number;
+}
 interface Enrollment {
-  id: number;
-  completedNumber: number;
-  course: Course;
+  enrollmentId: number;
+  courseId: number;
+  courseTitle: string;
+  totalLecturesCount: number;
+  completedLecturesCount: number;
+  totalQuizCount: number;
+  userSubmittedQuizCount: number;
+  userCorrectQuizCount: number;
+  lectures: Lecture[];
 }
 
 interface UserProfileResponse extends IUser {

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -18,7 +18,7 @@ export default async function Layout({
 }>) {
   return (
     <Suspense>
-      <div className="flex flex-row min-w-screen min-h-screen">
+      <div className="flex flex-row min-h-screen">
         <SideNav />
         {children}
       </div>

--- a/src/app/(admin)/admin/quizzes/descriptive/components/DescriptiveQuizColumn.tsx
+++ b/src/app/(admin)/admin/quizzes/descriptive/components/DescriptiveQuizColumn.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button";
 import { ColumnDef } from "@tanstack/react-table";
 import { ArrowUpDown } from "lucide-react";
 import { SortingHeader } from "../../../components/SortingHeader";
-import { departments, positions } from "@/app/types/type";
 import useOpenDescriptiveDialogStore from "@/store/useOpenDescriptiveDialogStore";
 import { QuizSubmitResponse } from "../hooks/useQuizSubmitQuery";
 
@@ -28,6 +27,7 @@ export const DescriptiveQuizColumn: ColumnDef<QuizSubmitResponse>[] = [
   },
   {
     accessorKey: "name",
+    size: 100,
     header: ({ column }) => {
       return (
         <Button
@@ -46,30 +46,25 @@ export const DescriptiveQuizColumn: ColumnDef<QuizSubmitResponse>[] = [
     enableHiding: false,
   },
   {
-    accessorKey: "position",
+    accessorKey: "positionLabel",
     header: ({ column }) => {
       return <SortingHeader column={column} title="직분" />;
     },
     cell: ({ row }) => {
-      const positionValue = row.getValue("position");
-      const positionLabel =
-        positions.find((pos) => pos.value === positionValue)?.label || "N/A";
+      const positionLabel = row.getValue("positionLabel") as string;
       return <div className="text-center">{positionLabel}</div>;
     },
     enableHiding: false,
   },
 
   {
-    accessorKey: "departmentName",
+    accessorKey: "departmentLabel",
     header: ({ column }) => {
       return <SortingHeader column={column} title="부서" />;
     },
     cell: ({ row }) => {
-      const departmentValue = row.getValue("departmentName");
-      const departmentLabel =
-        departments.find((dept) => dept.value === departmentValue)?.label ||
-        "N/A";
-      return <div className="text-center ">{departmentLabel}</div>;
+      const departmentValue = row.getValue("departmentLabel") as string;
+      return <div className="text-center ">{departmentValue}</div>;
     },
     enableHiding: false,
   },
@@ -83,25 +78,59 @@ export const DescriptiveQuizColumn: ColumnDef<QuizSubmitResponse>[] = [
     },
     enableHiding: false,
   },
+  // {
+  //   accessorKey: "lectureTitle",
+  //   header: ({ column }) => {
+  //     return <SortingHeader column={column} title="강의 이름" />;
+  //   },
+  //   cell: ({ row }) => {
+  //     return <div className="text-center">{row.getValue("lectureTitle")}</div>;
+  //   },
+  //   enableHiding: false,
+  // },
   {
-    accessorKey: "lectureTitle",
+    accessorKey: "quizType",
     header: ({ column }) => {
-      return <SortingHeader column={column} title="강의 이름" />;
+      return <SortingHeader column={column} title="퀴즈 유형" />;
     },
     cell: ({ row }) => {
-      return <div className="text-center">{row.getValue("lectureTitle")}</div>;
+      const quizType = row.getValue("quizType") as string;
+      return <div className="text-center">{quizType}</div>;
+    },
+    meta: {
+      filterVariant: "select",
     },
     enableHiding: false,
   },
   {
-    accessorKey: "status",
+    accessorKey: "answerType",
     header: ({ column }) => {
       return <SortingHeader column={column} title="채점 현황" />;
     },
     cell: ({ row }) => {
-      const status = row.getValue("status");
-      const result = status === 0 ? "미채점" : status === 1 ? "정답" : "오답";
-      return <div className="text-center">{result}</div>;
+      const answerType = row.getValue("answerType") as string;
+      // Define a function to return the appropriate class based on answerType
+      const getColorClass = (type: string) => {
+        switch (type) {
+          case "정답":
+            return "text-green-500";
+          case "오답":
+            return "text-red-500";
+          case "미채점":
+            return "text-orange-500";
+          default:
+            return "";
+        }
+      };
+
+      return (
+        <div className={`text-center ${getColorClass(answerType)}`}>
+          {answerType}
+        </div>
+      );
+    },
+    meta: {
+      filterVariant: "select",
     },
     enableHiding: false,
   },
@@ -111,6 +140,7 @@ export const DescriptiveQuizColumn: ColumnDef<QuizSubmitResponse>[] = [
       const { setOpen, setUserId, setQuizId } = useOpenDescriptiveDialogStore(
         (state) => state
       );
+      const quizType = row.getValue("quizType") as string;
       return (
         <Button
           variant="secondary"
@@ -121,7 +151,7 @@ export const DescriptiveQuizColumn: ColumnDef<QuizSubmitResponse>[] = [
             setQuizId(parseInt(row.getValue("quizId")));
           }}
         >
-          채점 하기
+          {quizType === "주관식" ? "채점하기" : "상세보기"}
         </Button>
       );
     },

--- a/src/app/(admin)/admin/quizzes/descriptive/components/DescriptiveQuizDialog.tsx
+++ b/src/app/(admin)/admin/quizzes/descriptive/components/DescriptiveQuizDialog.tsx
@@ -10,6 +10,17 @@ import { Label } from "@/components/ui/label";
 import { useQuizFeedbackMutation } from "../../hooks/useQuizFeedbackMutate";
 import useOpenDescriptiveDialogStore from "@/store/useOpenDescriptiveDialogStore";
 import { useMyDescriptiveQuizQuery } from "../../hooks/useQuizQuery";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 
 export default function DescriptiveQuizDialog() {
   const { data: session } = useSession();
@@ -41,61 +52,104 @@ export default function DescriptiveQuizDialog() {
   }
 
   return (
-    <div className="flex flex-col justify-center w-full h-full p-2 space-y-6 overflow-y-auto border">
-      <div>
-        <div className="text-xs">{`${descriptiveQuiz.quiz.lecture.course.title} > ${descriptiveQuiz.quiz.lecture.title} `}</div>
-        <div className="text-lg font-bold">
-          문제: {descriptiveQuiz.quiz.question}
-        </div>
-      </div>
-      <div>
-        주관식 퀴즈 채점 현황:{" "}
-        {descriptiveQuiz.status === 0
-          ? "미채점"
-          : descriptiveQuiz.status === 1
-          ? "정답"
-          : "오답"}
-      </div>
-      <div>
-        <div className="text-sm">제출한 답변</div>
-        <div className="p-4 border">{descriptiveQuiz.answer}</div>
-      </div>
-      <div>
-        <div className="text-sm">피드백 내용</div>
-        <Textarea
-          disabled={descriptiveQuiz.status !== 0}
-          value={value}
-          placeholder="피드백을 남겨주세요..."
-          onChange={onChange}
-        />
-        <div className="flex flex-row mt-2 space-x-4">
-          <div className="flex flex-row items-center justify-center gap-2">
-            <Checkbox
-              disabled={descriptiveQuiz.status !== 0}
-              id="correct"
-              onCheckedChange={() => setIsCorrected(true)}
-              checked={isCorrected}
-            />
-            <Label htmlFor="correct">정답</Label>
-          </div>
-          <div className="flex flex-row items-center justify-center gap-2">
-            <Checkbox
-              disabled={descriptiveQuiz.status !== 0}
-              id="incorrect"
-              onCheckedChange={() => setIsCorrected(false)}
-              checked={!isCorrected}
-            />
-            <Label htmlFor="incorrect">오답</Label>
+    <AlertDialog>
+      <div className="flex flex-col justify-center w-full h-full p-2 space-y-6 overflow-y-auto border">
+        <div>
+          <div className="text-xs">{`${descriptiveQuiz.quiz.lecture.course.title} > ${descriptiveQuiz.quiz.lecture.title} `}</div>
+          <div className="text-lg font-bold">
+            문제: {descriptiveQuiz.quiz.question}
           </div>
         </div>
+        <div>
+          주관식 퀴즈 채점 현황:{" "}
+          {descriptiveQuiz.status === 0
+            ? "미채점"
+            : descriptiveQuiz.status === 1
+            ? "정답"
+            : "오답"}
+        </div>
+        {descriptiveQuiz.multipleAnswer === 1 ? (
+          <div>
+            {descriptiveQuiz.quiz.quizAnswers.map((answer) => {
+              return (
+                <div
+                  className="flex flex-row gap-2 items-center p-2"
+                  key={answer.id}
+                >
+                  <Checkbox
+                    className="items-center"
+                    disabled
+                    checked={JSON.parse(descriptiveQuiz.answer).includes(
+                      answer.itemIndex
+                    )}
+                  />
+                  <span className="font-medium">{answer.item}</span>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <>
+            <div>
+              <div className="text-sm">제출한 답변</div>
+              <div className="p-4 border">{descriptiveQuiz.answer}</div>
+            </div>
+            <div>
+              <div className="text-sm">피드백 내용</div>
+              <Textarea
+                disabled={descriptiveQuiz.status !== 0}
+                value={value}
+                placeholder="피드백을 남겨주세요..."
+                onChange={onChange}
+              />
+              <div className="flex flex-row mt-2 space-x-4">
+                <div className="flex flex-row items-center justify-center gap-2">
+                  <Checkbox
+                    disabled={descriptiveQuiz.status !== 0}
+                    id="correct"
+                    onCheckedChange={() => setIsCorrected(true)}
+                    checked={isCorrected}
+                  />
+                  <Label htmlFor="correct">정답</Label>
+                </div>
+                <div className="flex flex-row items-center justify-center gap-2">
+                  <Checkbox
+                    disabled={descriptiveQuiz.status !== 0}
+                    id="incorrect"
+                    onCheckedChange={() => setIsCorrected(false)}
+                    checked={!isCorrected}
+                  />
+                  <Label htmlFor="incorrect">오답</Label>
+                </div>
+              </div>
+            </div>
+            <AlertDialogTrigger asChild>
+              <Button disabled={descriptiveQuiz.status !== 0} type="submit">
+                피드백 남기기
+              </Button>
+            </AlertDialogTrigger>
+          </>
+        )}
       </div>
-      <Button
-        disabled={descriptiveQuiz.status !== 0}
-        onClick={() => onSubmit(descriptiveQuiz.quiz.quizId)}
-        type="submit"
-      >
-        피드백 남기기
-      </Button>
-    </div>
+
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>피드백을 제출하시겠습니까?</AlertDialogTitle>
+          <AlertDialogDescription>
+            제출한 피드백은 수정할 수 없습니다. <br />
+            정답이 올바른지 한번 더 확인해주세요 <br />
+            정말 채점을 완료하시겠습니까?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>취소</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => onSubmit(descriptiveQuiz.quiz.quizId)}
+          >
+            확인
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/src/app/(admin)/admin/quizzes/descriptive/components/DescriptiveQuizInfoDialog.tsx
+++ b/src/app/(admin)/admin/quizzes/descriptive/components/DescriptiveQuizInfoDialog.tsx
@@ -196,16 +196,7 @@ export default function DescriptiveQuizInfoDialog({ type }: Props) {
                                       <p className="text-base font-bold text-black mt-4 mb-2">
                                         피드백 현황
                                       </p>
-                                      {/* <div className="flex p-2 border-2 rounded">
-                                      <p className="flex-row text-base text-black dark:text-white mr-2">
-                                        {ele.feedback}
-                                      </p>
-                                    </div> */}
-                                      <Textarea
-                                        className="text-black"
-                                        // placeholder={`${ele.feedback}`}
-                                        disabled
-                                      >
+                                      <Textarea className="text-black" disabled>
                                         {ele.feedback}
                                       </Textarea>
                                     </div>

--- a/src/app/(admin)/admin/quizzes/descriptive/components/Filter.tsx
+++ b/src/app/(admin)/admin/quizzes/descriptive/components/Filter.tsx
@@ -1,0 +1,78 @@
+import { useMemo } from "react";
+import DebouncedInput from "../../../users/components/DebouncedInput";
+import { Column, RowData } from "@tanstack/react-table";
+import "@tanstack/react-table";
+
+declare module "@tanstack/react-table" {
+  interface ColumnMeta<TData extends RowData, TValue> {
+    filterVariant?: "text" | "range" | "select";
+  }
+}
+
+export default function Filter({ column }: { column: Column<any, unknown> }) {
+  const { filterVariant } = column.columnDef.meta ?? {};
+
+  const columnFilterValue = column.getFilterValue();
+
+  const sortedUniqueValues = useMemo(
+    () =>
+      filterVariant === "range"
+        ? []
+        : Array.from(column.getFacetedUniqueValues().keys())
+            .sort()
+            .slice(0, 5000),
+    [column.getFacetedUniqueValues(), filterVariant]
+  );
+
+  return filterVariant === "range" ? (
+    <div>
+      <div className="flex space-x-2">
+        <DebouncedInput
+          type="number"
+          min={Number(column.getFacetedMinMaxValues()?.[0] ?? "")}
+          max={Number(column.getFacetedMinMaxValues()?.[1] ?? "")}
+          value={(columnFilterValue as [number, number])?.[0] ?? ""}
+          onChange={(value) =>
+            column.setFilterValue((old: [number, number]) => [value, old?.[1]])
+          }
+          placeholder={`Min ${
+            column.getFacetedMinMaxValues()?.[0] !== undefined
+              ? `(${column.getFacetedMinMaxValues()?.[0]})`
+              : ""
+          }`}
+          className="w-24 border shadow rounded"
+        />
+        <DebouncedInput
+          type="number"
+          // min={Number(column.getFacetedMinMaxValues()?.[0] ?? "")}
+          // max={Number(column.getFacetedMinMaxValues()?.[1] ?? "")}
+          value={(columnFilterValue as [number, number])?.[1] ?? ""}
+          onChange={(value) =>
+            column.setFilterValue((old: [number, number]) => [old?.[0], value])
+          }
+          placeholder={`Max ${
+            column.getFacetedMinMaxValues()?.[1]
+              ? `(${column.getFacetedMinMaxValues()?.[1]})`
+              : ""
+          }`}
+          className="w-24 border shadow rounded"
+        />
+      </div>
+      <div className="h-1" />
+    </div>
+  ) : (
+    <select
+      className="w-full text-center"
+      onChange={(e) => column.setFilterValue(e.target.value)}
+      value={columnFilterValue?.toString()}
+    >
+      <option value="">All</option>
+      {sortedUniqueValues.map((value) => (
+        //dynamically generated select options from faceted values feature
+        <option value={value} key={value}>
+          {value}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/app/(admin)/admin/quizzes/descriptive/hooks/useQuizSubmitQuery.ts
+++ b/src/app/(admin)/admin/quizzes/descriptive/hooks/useQuizSubmitQuery.ts
@@ -4,6 +4,7 @@ import { IUser } from "@/model/user";
 import { IQuiz } from "@/model/quiz";
 import { ILecture } from "@/model/lecture";
 import { ICourse } from "@/model/course";
+import { getAllQuizSubmit } from "../lib/getAllQuizSubmit";
 
 interface Quiz extends IQuiz {
   lecture: Lecture;
@@ -18,10 +19,14 @@ export interface QuizSubmitResponse {
   name: string;
   userId: number;
   quizId: number;
+  quizType: string;
   position: string;
   departmentName: string;
+  departmentLabel: string;
+  positionLabel: string;
   lectureTitle: string;
   courseTitle: string;
+  answerType: string;
   status: number;
   user: IUser;
   quiz: Quiz;
@@ -34,6 +39,17 @@ export const useQuizSubmitQuery = (
   return useQuery<QuizSubmitResponse[]>({
     queryKey: ["quizSubmits"],
     queryFn: () => getQuizSubmit(accessToken),
+    enabled: !!accessToken,
+  });
+};
+
+export const useAllQuizSubmitQuery = (
+  accessToken: string,
+  options?: { enabled?: boolean }
+) => {
+  return useQuery<QuizSubmitResponse[]>({
+    queryKey: ["quizSubmits"],
+    queryFn: () => getAllQuizSubmit(accessToken),
     enabled: !!accessToken,
   });
 };

--- a/src/app/(admin)/admin/quizzes/descriptive/lib/getAllQuizSubmit.ts
+++ b/src/app/(admin)/admin/quizzes/descriptive/lib/getAllQuizSubmit.ts
@@ -1,0 +1,18 @@
+export async function getAllQuizSubmit(accessToken: string) {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/admin/quizzes/all`,
+    {
+      next: {
+        tags: ["quizSubmits"],
+      },
+      headers: { authorization: `Bearer ${accessToken}` },
+      credentials: "include",
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to get quizSubmits");
+  }
+
+  return response.json();
+}

--- a/src/app/(admin)/admin/quizzes/descriptive/page.tsx
+++ b/src/app/(admin)/admin/quizzes/descriptive/page.tsx
@@ -17,9 +17,9 @@ export default function AdminQuizPage() {
   }
 
   return (
-    <div className="h-full w-full p-4 space-y-2">
+    <div className="flex-1 flex flex-col p-4 space-y-2">
       <div className="text-xl font-bold font-sans">주관식 퀴즈 관리</div>
-      <div className="flex flex-col p-2 h-full">
+      <div className="flex flex-col p-2 h-[650px]">
         <DescriptiveDataTableQuiz
           columns={DescriptiveQuizColumn}
           data={quizSubmits}

--- a/src/app/(admin)/admin/quizzes/hooks/useQuizQuery.ts
+++ b/src/app/(admin)/admin/quizzes/hooks/useQuizQuery.ts
@@ -25,6 +25,7 @@ export const useFetchAdminLectureQuizList = (
 };
 
 interface Quiz extends IQuiz {
+  quizAnswers: IQuizAnswer[];
   lecture: Lecture;
 }
 interface Lecture extends ILecture {

--- a/src/app/(admin)/admin/quizzes/page.tsx
+++ b/src/app/(admin)/admin/quizzes/page.tsx
@@ -18,16 +18,10 @@ export default function AdminQuizPage() {
             채점 관리 화면
             <div className="flex flex-row space-x-2 w-full p-4">
               <Link
-                href={"/admin/quizzes/multiple"}
-                className=" w-full max-w-xl p-10 items-center justify-center rounded-lg bg-blue-200 px-8 text-2xl  text-black shadow transition-colors hover:bg-blue-600 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-700 disabled:pointer-events-none disabled:opacity-50 dark:bg-blue-400 dark:hover:bg-blue-400 dark:focus-visible:ring-blue-300"
-              >
-                객관식 관리
-              </Link>
-              <Link
                 href={"/admin/quizzes/descriptive"}
                 className=" w-full max-w-xl p-10 items-center justify-center rounded-lg bg-orange-200 px-8 text-2xl  text-black shadow transition-colors hover:bg-orange-600 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-700 disabled:pointer-events-none disabled:opacity-50 dark:bg-blue-400 dark:hover:bg-blue-400 dark:focus-visible:ring-blue-300"
               >
-                주관식 관리
+                퀴즈 관리
               </Link>
             </div>
           </div>

--- a/src/app/(admin)/admin/quizzes/register/components/RegisterQuizTable.tsx
+++ b/src/app/(admin)/admin/quizzes/register/components/RegisterQuizTable.tsx
@@ -102,83 +102,73 @@ export function RegisterQuizTable<TData, TValue>({
   });
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <div className="flex flex-col flex-1 justify-between overflow-y-auto">
-        <div className="flex flex-col justify-start overflow-y-scroll">
-          <DialogContent
-            onOpenAutoFocus={(e) => e.preventDefault()}
-            className="w-[600px] h-[646px] overflow-y-auto"
-          >
-            <DialogHeader>
-              <DialogTitle>강의 등록 퀴즈 현황</DialogTitle>
-              <DialogDescription>
-                강의별 등록된 퀴즈들을 확인합니다.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="flex items-center space-x-2">
-              <RegisterQuizDialog />
-            </div>
-            <DialogFooter className="sm:justify-end">
-              <DialogClose asChild>
-                <Button type="button" variant="secondary">
-                  닫기
-                </Button>
-              </DialogClose>
-            </DialogFooter>
-          </DialogContent>
-          <div className="relative justify-start items-center w-full h-full flex mr-auto flex-1 md:grow-0"></div>
-          <Table className="relative container justify-start mx-auto py-2 overflow-y-auto">
-            <TableHeader className="sticky top-0 bg-white">
-              {table.getHeaderGroups().map((headerGroup) => (
-                <TableRow key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    return (
-                      <TableHead key={header.id}>
-                        {header.isPlaceholder
-                          ? null
-                          : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext()
-                            )}
-                      </TableHead>
-                    );
-                  })}
-                </TableRow>
-              ))}
-            </TableHeader>
-            <TableBody>
-              {table.getRowModel().rows?.length ? (
-                table.getRowModel().rows.map((row) => (
-                  <TableRow
-                    key={row.id}
-                    data-state={row.getIsSelected() && "selected"}
-                    onClick={() => {}}
-                  >
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell className="cursor-pointer" key={cell.id}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext()
+    <>
+      <Table className="justify-start relative w-full">
+        <TableHeader className="sticky top-0 bg-white">
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
                         )}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))
-              ) : (
-                <TableRow>
-                  <TableCell
-                    colSpan={columns.length}
-                    className="h-24 text-center"
-                  >
-                    검색 결과가 없습니다.
+                  </TableHead>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+                onClick={() => {}}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell className="cursor-pointer" key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
-        </div>
-        {/* <DataTablePagination table={table} /> */}
-      </div>
-    </Dialog>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="text-center">
+                검색 결과가 없습니다.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          className="w-[600px] h-[646px] overflow-y-auto"
+        >
+          <DialogHeader>
+            <DialogTitle>강의 등록 퀴즈 현황</DialogTitle>
+            <DialogDescription>
+              강의별 등록된 퀴즈들을 확인합니다.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex items-center space-x-2">
+            <RegisterQuizDialog />
+          </div>
+          <DialogFooter className="sm:justify-end">
+            <DialogClose asChild>
+              <Button type="button" variant="secondary">
+                닫기
+              </Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/app/(admin)/admin/quizzes/register/components/RegisterTableColumn.tsx
+++ b/src/app/(admin)/admin/quizzes/register/components/RegisterTableColumn.tsx
@@ -22,19 +22,10 @@ export const RegisterQuizColumn: ColumnDef<AllLecturesResponse>[] = [
   {
     accessorKey: "title",
     header: ({ column }) => {
-      return (
-        <Button
-          className="w-full"
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          강의 제목
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
+      return <SortingHeader column={column} title="강의 제목" />;
     },
     cell: (info) => {
-      return <div className="text-center">{`${info.getValue()}`}</div>;
+      return <div className="text-left">{`${info.getValue()}`}</div>;
     },
     enableHiding: false,
   },
@@ -45,7 +36,7 @@ export const RegisterQuizColumn: ColumnDef<AllLecturesResponse>[] = [
       return <SortingHeader column={column} title="강의 회차" />;
     },
     cell: (info) => {
-      return <div className="text-center">{`${info.getValue()}강`}</div>;
+      return <div className="text-left">{`${info.getValue()}강`}</div>;
     },
     enableHiding: false,
   },

--- a/src/app/(admin)/admin/quizzes/register/page.tsx
+++ b/src/app/(admin)/admin/quizzes/register/page.tsx
@@ -46,14 +46,14 @@ export default function RegisterQuizPage() {
   }));
 
   return (
-    <main id="main" className="flex flex-col w-full h-screen items-start p-8">
+    <main id="main" className="flex flex-col w-full items-start p-8">
       <div
         id="div1"
         className="flex flex-row w-full items-start p-2 border-b-2 border-gray-300 "
       >
         <h2 className="text-2xl font-sans">퀴즈 등록 화면</h2>
       </div>
-      <div id="div2" className="flex flex-row p-2 mt-2  items-center">
+      <div id="div2" className="flex flex-row p-2 mt-2 items-center">
         <p className="text-base font-bold font-sans mr-4 text-center">
           코스 선택
         </p>
@@ -86,23 +86,12 @@ export default function RegisterQuizPage() {
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      <div id="div3" className="flex flex-col w-full h-full p-2 ">
-        <div
-          id="div3-1"
-          className="flex w-full h-full items-start justify-center overflow-y-scroll"
-        >
-          {lectures && selectedCourseId ? (
-            <RegisterQuizTable columns={RegisterQuizColumn} data={lectures} />
-          ) : (
-            <div>코스를 선택해주세요</div>
-          )}
-        </div>
-        {/* <div
-          id="div3-2"
-          className="flex flex-row w-full h-auto mt-2 bg-yellow-300 items-start justify-end p-4"
-        >
-          페이지 네이션 들어갈 곳
-        </div> */}
+      <div id="div3" className="flex flex-col w-full h-[540px] p-2">
+        {lectures && selectedCourseId ? (
+          <RegisterQuizTable columns={RegisterQuizColumn} data={lectures} />
+        ) : (
+          <div>코스를 선택해주세요</div>
+        )}
       </div>
     </main>
   );

--- a/src/app/(admin)/admin/users/components/SortingHeader.tsx
+++ b/src/app/(admin)/admin/users/components/SortingHeader.tsx
@@ -34,6 +34,7 @@ export function SortingHeader<TData, TValue>({
 
   return (
     <Button
+      className="w-full"
       variant="ghost"
       onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
     >

--- a/src/app/(admin)/admin/users/components/UserInfoDialog.tsx
+++ b/src/app/(admin)/admin/users/components/UserInfoDialog.tsx
@@ -4,6 +4,15 @@ import { useSession } from "next-auth/react";
 import Loading from "@/app/(lecture)/course/[courseId]/lecture/[lectureId]/loading";
 import UserForm from "./UserForm";
 import { useFetchUserProfileByIdQuery } from "../../hooks/useUserQuery";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { FaCircleCheck, FaCircleMinus } from "react-icons/fa6";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Circle, X } from "lucide-react";
 
 type Props = {
   userId: number;
@@ -28,13 +37,162 @@ export function UserInfoDialog({ userId }: Props) {
       <div className="space-y-2">
         <h1 className="font-semibold text-lg">수강 중인 강의</h1>
         {userProfile.enrollments.length > 0 ? (
-          <ul className="space-y-2">
-            {userProfile.enrollments.map((enrollment) => (
-              <li className="bg-gray-100 p-2 text-center" key={enrollment.id}>
-                {enrollment.course?.title || "제목 없음"}{" "}
-              </li>
-            ))}
-          </ul>
+          <Accordion type="single" collapsible className="w-full">
+            {userProfile.enrollments.map((enrollment) => {
+              return (
+                <AccordionItem
+                  className="border w-full border-black"
+                  value={enrollment.enrollmentId.toString()}
+                  key={enrollment.enrollmentId}
+                >
+                  <AccordionTrigger>
+                    <div className="flex flex-row w-full items-center">
+                      <div className="font-bold w-full">
+                        {enrollment.courseTitle}
+                      </div>
+                      <div className="w-full">
+                        수강현황: {enrollment.completedLecturesCount}/
+                        {enrollment.totalLecturesCount}
+                      </div>
+                      <div className="w-full">
+                        (
+                        {(enrollment.completedLecturesCount /
+                          enrollment.totalLecturesCount) *
+                          100}
+                        %)
+                      </div>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent className="p-4 space-y-2">
+                    <Accordion type="single" collapsible className="w-full">
+                      {enrollment.lectures.map((lecture, index) => {
+                        return (
+                          <AccordionItem
+                            className="border w-full "
+                            value={lecture.lectureId.toString()}
+                            key={lecture.lectureId}
+                          >
+                            <AccordionTrigger>
+                              <div className="flex flex-row w-full items-center">
+                                <div className="font-bold w-full">
+                                  {lecture.lectureNumber}강.{" "}
+                                  {lecture.lectureTitle}
+                                </div>
+                                <div className="w-full">
+                                  퀴즈현황: {lecture.correctQuizCount}/
+                                  {lecture.quizTotalCount}
+                                </div>
+                                <FaCircleCheck
+                                  size={24}
+                                  className={` w-1/2 ${
+                                    index + 1 <=
+                                    enrollment.completedLecturesCount
+                                      ? "text-blue-500"
+                                      : "text-gray-300"
+                                  }`}
+                                />
+                                {/* <div className="w-full">
+                                  (
+                                  {(lecture.correctQuizCount /
+                                    lecture.quizTotalCount) *
+                                    100 || 0}
+                                  점)
+                                </div> */}
+                              </div>
+                            </AccordionTrigger>
+                            <AccordionContent className="p-4 space-y-2">
+                              {lecture.quizzes.length > 0 ? (
+                                <div className="p-2 space-y-4">
+                                  {lecture.quizzes.map((quiz) => {
+                                    if (quiz.quizType === "multiple") {
+                                      // 객관식 퀴즈
+                                      return (
+                                        <div key={quiz.quizId}>
+                                          <div className="flex flex-row items-center justify-between">
+                                            <div>
+                                              (객관식) 질문: {quiz.question}
+                                            </div>
+                                            {quiz.answerType === "정답" ? (
+                                              <Circle color="green" />
+                                            ) : (
+                                              <X color="red" />
+                                            )}
+                                          </div>
+                                          <div className="text-gray-400">
+                                            시도 횟수({quiz.submitCount}번)
+                                          </div>
+                                          <div className="border">
+                                            {quiz.quizAnswers.map((answer) => {
+                                              if (quiz.answer) {
+                                                return (
+                                                  <div
+                                                    className="flex flex-row gap-2 items-center p-2"
+                                                    key={answer.id}
+                                                  >
+                                                    <Checkbox
+                                                      className="items-center"
+                                                      disabled
+                                                      checked={quiz.answer.includes(
+                                                        answer.itemIndex as number
+                                                      )}
+                                                    />
+                                                    <span className="font-medium">
+                                                      {answer.item}
+                                                    </span>
+                                                  </div>
+                                                );
+                                              } else {
+                                                return <div>미제출</div>;
+                                              }
+                                            })}
+                                          </div>
+                                        </div>
+                                      );
+                                    } else if (
+                                      quiz.quizType === "descriptive"
+                                    ) {
+                                      // 주관식 퀴즈
+                                      return (
+                                        <div className="" key={quiz.quizId}>
+                                          <div className="flex flex-row justify-between items-center">
+                                            (주관식) 질문: {quiz.question}
+                                            {quiz.answerType === "정답" ? (
+                                              <Circle color="green" />
+                                            ) : quiz.answerType === "오답" ? (
+                                              <X color="red" />
+                                            ) : (
+                                              <FaCircleMinus color="orange" />
+                                            )}
+                                          </div>
+                                          {quiz.answer ? (
+                                            <div className="border p-2">
+                                              답변: {quiz.answer}
+                                            </div>
+                                          ) : (
+                                            <div>미제출</div>
+                                          )}
+                                        </div>
+                                      );
+                                    } else {
+                                      return null;
+                                    }
+                                  })}
+                                </div>
+                              ) : (
+                                <div className="p-2">
+                                  등록된 퀴즈가 없습니다.
+                                </div>
+                              )}
+                            </AccordionContent>
+                          </AccordionItem>
+                        );
+                      })}
+                    </Accordion>
+                  </AccordionContent>
+                </AccordionItem>
+              );
+            })}
+          </Accordion>
         ) : (
           <div className="text-center">수강 신청한 이력이 없습니다.</div>
         )}

--- a/src/app/(admin)/admin/videos/components/DataTable.tsx
+++ b/src/app/(admin)/admin/videos/components/DataTable.tsx
@@ -11,6 +11,7 @@ import {
   FilterFn,
   getFilteredRowModel,
   ColumnResizeMode,
+  ColumnSizing,
 } from "@tanstack/react-table";
 
 import {
@@ -63,6 +64,8 @@ export function DataTable<TData, TValue>({
   // const [columnResizeMode, setColumnResizeMode] =
   //   useState<ColumnResizeMode>("onChange");
 
+  // console.log("sdf");
+
   const router = useRouter();
 
   const table = useReactTable({
@@ -91,7 +94,13 @@ export function DataTable<TData, TValue>({
       sorting,
       rowSelection,
     },
+    defaultColumn: {
+      // size: 200, //starting column size
+      // minSize: 50, //enforced during column resizing
+      // maxSize: 200,
+    },
   });
+  // console.log(table.getCenterTotalSize());
 
   return (
     <div className="flex flex-col justify-between flex-1 overflow-y-auto">
@@ -128,7 +137,8 @@ export function DataTable<TData, TValue>({
                     <TableHead
                       key={header.id}
                       colSpan={header.colSpan}
-                      className={`w-[${header.getSize()}px] `}
+                      // style={{ width: `${header.getSize()}px` }}
+                      className={`w-[${header.getSize()}px]`}
                     >
                       {header.isPlaceholder
                         ? null
@@ -149,17 +159,19 @@ export function DataTable<TData, TValue>({
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
                 >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell
-                      className={`cursor-pointer w-[${cell.column.getSize()}]`}
-                      key={cell.id}
-                    >
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </TableCell>
-                  ))}
+                  {row.getVisibleCells().map((cell) => {
+                    return (
+                      <TableCell
+                        className={`w-[${cell.column.getSize()}px]`}
+                        key={cell.id}
+                      >
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </TableCell>
+                    );
+                  })}
                 </TableRow>
               ))
             ) : (

--- a/src/app/(admin)/admin/videos/components/columns.tsx
+++ b/src/app/(admin)/admin/videos/components/columns.tsx
@@ -64,8 +64,14 @@ export const videoColumns: ColumnDef<AdminCoursesResponse>[] = [
       return <SortingHeader column={column} title="강의명" />;
     },
     cell: ({ row }) => {
-      return <div className="text-center">{row.getValue("title")}</div>;
+      return (
+        <div className="text-center w-full whitespace-normal break-words">
+          {row.getValue("title")}
+        </div>
+      );
     },
+    size: 50,
+    maxSize: 50,
   },
   {
     accessorKey: "enrollmentCount",
@@ -118,7 +124,21 @@ export const videoColumns: ColumnDef<AdminCoursesResponse>[] = [
       return <SortingHeader column={column} title="마감 기한" />;
     },
     cell: ({ row }) => {
-      return <div>{formatDate(new Date(row.getValue("finishDate")))}</div>;
+      return (
+        <div className="text-center">
+          {formatDate(new Date(row.getValue("finishDate")))}
+        </div>
+      );
+    },
+  },
+  {
+    id: "quizCount",
+    accessorFn: (row) => `객${row.multipleCount}/주${row.descriptiveCount}`,
+    header: ({ column }) => {
+      return <SortingHeader column={column} title="퀴즈갯수" />;
+    },
+    cell: (info) => {
+      return <div className="text-center">{info.getValue() as string}</div>;
     },
   },
   {

--- a/src/app/(admin)/admin/videos/edit/components/CourseEdit.tsx
+++ b/src/app/(admin)/admin/videos/edit/components/CourseEdit.tsx
@@ -147,22 +147,20 @@ export default function CourseEdit({ courseInfo }: Props) {
   }
 
   return (
-    <div className="relative flex flex-col items-center justify-center w-full h-screen p-2 py-4">
+    <div className="relative flex flex-col items-center justify-center w-full h-full p-6">
       <X
         onClick={() => router.back()}
         className="absolute w-8 h-8 rounded-full right-10 top-10 hover:bg-black hover:bg-opacity-20"
       />
       <h2 className="mb-4 text-2xl">코스 편집</h2>
-      <div className="flex flex-row overflow-y-auto w-full p-2 space-x-2">
+      <div className="flex flex-row w-full p-2 space-x-2 h-full">
         <Form {...form}>
           <form
-            // id="courseEdit"
             autoComplete="off"
             autoFocus={false}
             onSubmit={form.handleSubmit(onSubmit)}
-            className="flex flex-col w-1/2 p-10 space-y-4 overflow-y-auto"
+            className="flex flex-col w-1/2 p-10 rounded-lg space-y-4 overflow-y-auto border"
           >
-            {/* <div className="flex flex-row w-full justify-between space-x-2 overflow-y-auto"> */}
             <div className="flex flex-col justify-between p-2 space-y-2 overflow-y-auto w-full">
               <FormField
                 control={form.control}
@@ -367,7 +365,6 @@ export default function CourseEdit({ courseInfo }: Props) {
                 )}
               />
             </div>
-            {/* </div> */}
             <Button className="w-full mt-10" type="submit">
               코스 정보 수정
             </Button>

--- a/src/app/(admin)/admin/videos/edit/page.tsx
+++ b/src/app/(admin)/admin/videos/edit/page.tsx
@@ -23,10 +23,8 @@ export default function Page() {
   }
 
   return (
-    <div className="w-full h-screen">
-      {/* <Suspense> */}
+    <div className="w-full h-screen p-4 overflow-hidden">
       <CourseEdit courseInfo={courseInfo} />
-      {/* </Suspense> */}
     </div>
   );
 }

--- a/src/app/(admin)/admin/videos/hook/useCourseEditMutation.ts
+++ b/src/app/(admin)/admin/videos/hook/useCourseEditMutation.ts
@@ -21,6 +21,7 @@ export function useCourseEditMutation(accessToken: string, courseId: number) {
           body: data,
         }
       );
+      console.log(response);
       if (!response.ok) {
         const errorData = await response.json(); // 에러 메시지를 포함할 수 있는 응답의 본문
         throw {
@@ -51,11 +52,19 @@ export function useCourseEditMutation(accessToken: string, courseId: number) {
       });
     },
     onError: (error: any) => {
-      toast({
-        variant: "destructive",
-        title: "잘못된 양식입니다..",
-        description: "잠시 후 다시 시도해주세요.",
-      });
+      if (error.status === 413) {
+        toast({
+          variant: "destructive",
+          title: "파일 용량이 너무 큽니다.",
+          description: "파일 용량을 줄여주세요.",
+        });
+      } else {
+        toast({
+          variant: "destructive",
+          title: error.message,
+          description: "다시 시도해주세요.",
+        });
+      }
       console.error(
         "There was a problem with your fetch operation:",
         error.message

--- a/src/app/(admin)/admin/videos/hook/useCourseMutation.ts
+++ b/src/app/(admin)/admin/videos/hook/useCourseMutation.ts
@@ -13,7 +13,7 @@ export function useCourseMutation() {
   const router = useRouter(); // router 사용 설정
 
   return useMutation({
-    mutationKey: ["updateCourseByAdmin"],
+    mutationKey: ["createCourseByAdmin"],
     mutationFn: async ({ accessToken, data }: UserPatchRequest) => {
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL}/admin/courses`,
@@ -49,8 +49,8 @@ export function useCourseMutation() {
       // 이곳에서 error 객체의 status에 따라 다른 toast 메시지를 출력
       toast({
         variant: "destructive",
-        title: "잘못된 양식입니다..",
-        description: "잠시 후 다시 시도해주세요.",
+        title: error.message,
+        description: "다시 시도해주세요.",
       });
       console.error(
         "There was a problem with your fetch operation:",

--- a/src/app/(admin)/admin/videos/register/page.tsx
+++ b/src/app/(admin)/admin/videos/register/page.tsx
@@ -78,6 +78,7 @@ export default function Page() {
 
     Object.keys(data).forEach((key) => {
       if (key === "thumbnailImage") {
+        console.log(imageFile);
         formData.append("thumbnailImage", imageFile as Blob);
       } else {
         formData.append(key, data[key as keyof typeof data]);

--- a/src/app/(home)/_components/Header.tsx
+++ b/src/app/(home)/_components/Header.tsx
@@ -80,17 +80,19 @@ export default function Header() {
                   >
                     강의 목록
                   </Link>
-                  {session && session.user.level === "admin" && (
-                    <Link
-                      className="w-full text-left hover:text-blue-900"
-                      href="/admin/users"
-                      onClick={() => {
-                        setIsOpen(false);
-                      }}
-                    >
-                      관리자 페이지
-                    </Link>
-                  )}
+                  {session &&
+                    (session.user.level === "admin" ||
+                      session.user.level === "tutor") && (
+                      <Link
+                        className="w-full text-left hover:text-blue-900"
+                        href="/admin/users"
+                        onClick={() => {
+                          setIsOpen(false);
+                        }}
+                      >
+                        관리자 페이지
+                      </Link>
+                    )}
                   {session ? (
                     <>
                       <Link
@@ -110,6 +112,12 @@ export default function Header() {
                         }}
                       >
                         공지사항
+                      </Link>
+                      <Link
+                        className="w-full text-left hover:text-blue-900"
+                        href={`/qna`}
+                      >
+                        질문게시판
                       </Link>
                       <Link
                         className="w-full text-left hover:text-blue-900"
@@ -167,11 +175,13 @@ export default function Header() {
             <Link className="mr-5 hover:text-blue-900" href="/course">
               강의 목록
             </Link>
-            {session && session.user.level === "admin" && (
-              <Link className="mr-5 hover:text-blue-900" href="/admin/users">
-                관리자 페이지
-              </Link>
-            )}
+            {session &&
+              (session.user.level === "admin" ||
+                session.user.level === "tutor") && (
+                <Link className="mr-5 hover:text-blue-900" href="/admin/users">
+                  관리자 페이지
+                </Link>
+              )}
             {session ? (
               <>
                 <Link className="mr-5 hover:text-blue-900" href="/myDashboard">
@@ -182,6 +192,9 @@ export default function Header() {
                   href={`/notice?page=1`}
                 >
                   공지사항
+                </Link>
+                <Link className="mr-5 hover:text-blue-900" href={`/qna`}>
+                  질문게시판
                 </Link>
                 <Link
                   className="mr-5 hover:text-blue-900"

--- a/src/app/(home)/_components/MainCourseCard.tsx
+++ b/src/app/(home)/_components/MainCourseCard.tsx
@@ -14,6 +14,10 @@ export default function CourseCard() {
 
   const { data: courses, isPending, error } = useFetchAllCourseListQuery();
 
+  function numSort(a: number, b: number) {
+    return a - b;
+  }
+
   useEffect(() => {
     if (courses) {
       const newCategories: { [key: string]: any[] } = {};
@@ -39,7 +43,7 @@ export default function CourseCard() {
           <h2 className="text-2xl font-bold">{category}</h2>{" "}
           {/* 카테고리 이름 표시 */}
           <div className="p-6 grid grid-cols-1 place-items-center gap-10 sm:gap-6 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-3">
-            {categories[category].map((course) => (
+            {categories[category].sort(numSort).map((course) => (
               <div
                 key={course.courseId}
                 className="min-w-0 shadow-xl rounded-2xl border flex flex-col justify-between max-w-[410px] w-full h-full mx-auto"
@@ -51,7 +55,9 @@ export default function CourseCard() {
                   // layout="fill" // This makes the image fill the container while respecting aspect ratio
                   // objectFit="none" // Adjust as needed: cover, contain, etc.
                   src={`${process.env.NEXT_PUBLIC_IMAGE_URL}${course.thumbnailImagePath}`}
-                  style={{ objectFit: "contain" }}
+                  style={{
+                    objectFit: "contain",
+                  }}
                   alt="강의 썸네일"
                   priority
                 />

--- a/src/app/(home)/introduce/page.tsx
+++ b/src/app/(home)/introduce/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import IntroImage from "../../../../public/images/introduceImage.jpeg";
 import IntroBackground from "../../../../public/images/introBackground.jpg";
+import { AspectRatio } from "@/components/ui/aspect-ratio";
 
 export default function IntroducePage() {
   return (
@@ -10,7 +11,7 @@ export default function IntroducePage() {
           <div className="relative flex flex-col justify-center w-full h-40">
             <Image
               src={IntroBackground}
-              style={{ width: "100%", height: "160px", objectFit: "cover" }}
+              style={{ width: "100%", height: "100px", objectFit: "cover" }}
               alt="인트로 배경"
             />
             <div
@@ -24,12 +25,14 @@ export default function IntroducePage() {
 
           <div id="introText" className="flex flex-col md:flex-row">
             <div className="p-4 md:p-16 md:pr-48 flex flex-col md:flex-row w-full ">
-              <div className="flex w-full md:w-[580px] md:h-[480px] m-4">
-                <Image
-                  alt="Profile"
-                  className="rounded-lg animate-slide-in w-full h-auto"
-                  src={IntroImage}
-                />
+              <div className="flex w-full md:w-[580px] md:h-[480px] m-4 mb-10">
+                <AspectRatio ratio={4 / 3} className="">
+                  <Image
+                    alt="Profile"
+                    className="rounded-lg animate-slide-in w-full h-auto"
+                    src={IntroImage}
+                  />
+                </AspectRatio>
               </div>
               <div className="space-y-4 text-sm text-gray-600 flex flex-col w-full m-4 md:m-8 animate-slide-out">
                 <p>

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -19,7 +19,7 @@ export default async function Layout({
 }>) {
   return (
     <>
-      <div className="flex flex-col min-w-screen min-h-screen">
+      <div className="flex flex-col min-h-screen">
         <Header />
         <main className="flex-auto overflow-y-auto">{children}</main>
         <Footer />

--- a/src/app/(home)/myDashboard/components/CourseCardDashboard.tsx
+++ b/src/app/(home)/myDashboard/components/CourseCardDashboard.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { CourseDetail } from "../hooks/useDashboard";
+import { AspectRatio } from "@/components/ui/aspect-ratio";
 
 interface DashboardProps {
   data: CourseDetail;
@@ -21,7 +22,7 @@ export default function CourseCardDashboard({ data }: DashboardProps) {
 
   return (
     <div className="md:w-full h-full">
-      <Card className="h-full flex flex-col justify-betweenshadow-xl rounded-2xl max-w-md md:max-w-lg flex-grow">
+      <Card className="h-full flex w-[300px] flex-col justify-betweenshadow-xl rounded-2xl max-w-md md:max-w-lg flex-grow">
         <CardHeader>
           <CardTitle className="text-sm md:text-base lg:text-lg">
             {data.title}
@@ -29,14 +30,15 @@ export default function CourseCardDashboard({ data }: DashboardProps) {
           <CardDescription>{data.curriculum}</CardDescription>
         </CardHeader>
         <CardContent>
-          <Image
-            src={`${process.env.NEXT_PUBLIC_IMAGE_URL}${data.thumbnailPath}`}
-            width={200}
-            height={200}
-            style={{ width: "100%", height: "auto" }}
-            alt="Thumbnail"
-            priority
-          />
+          <AspectRatio ratio={16 / 9} className="bg-muted">
+            <Image
+              src={`${process.env.NEXT_PUBLIC_IMAGE_URL}${data.thumbnailPath}`}
+              fill
+              className="rounded-md object-contain"
+              alt="Thumbnail"
+              priority
+            />
+          </AspectRatio>
           <div className="mt-2 text-xs md:text-sm lg:text-lg">{data.title}</div>
 
           <Progress
@@ -61,13 +63,14 @@ export default function CourseCardDashboard({ data }: DashboardProps) {
         <CardFooter>
           <Button
             className="w-full"
+            disabled={data.status === "inactive"}
             onClick={() => {
               router.push(
                 `/course/${data.courseId}/lecture/${data.lastStudyLectureId}`
               );
             }}
           >
-            이어보기
+            {data.status === "active" ? "이어보기" : "강의마감"}
           </Button>
         </CardFooter>
       </Card>

--- a/src/app/(home)/myDashboard/hooks/useDashboard.ts
+++ b/src/app/(home)/myDashboard/hooks/useDashboard.ts
@@ -8,6 +8,7 @@ interface DashBoardResponse {
 
 export interface CourseDetail {
   courseId: number;
+  status: string;
   title: string;
   curriculum: string;
   thumbnailPath: string | null;

--- a/src/app/(home)/notice/page.tsx
+++ b/src/app/(home)/notice/page.tsx
@@ -34,7 +34,8 @@ export default function Page({
       <div className="w-full p-8">
         <DataTable columns={columns} data={posts.posts || []} />
       </div>
-      {session?.user.level === "admin" && (
+      {(session?.user.level === "admin" ||
+        session?.user.level === "manager") && (
         <Link
           className="p-4 text-white bg-blue-500 border hover:bg-blue-700"
           href="/notice/register"

--- a/src/app/(home)/signup/components/EmailVerification.tsx
+++ b/src/app/(home)/signup/components/EmailVerification.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { formatTime } from "../../findPassword/lib/formatTime";
+import { toast } from "@/components/ui/use-toast";
+import useEmailVerifyStore from "@/store/useEmailVerifyStore";
+
+type Props = {
+  email: string;
+};
+
+export default function EmailVerification({ email }: Props) {
+  const [verificationCodeInput, setVerificationCodeInput] = useState("");
+  const [isTimeout, setIsTimeout] = useState(false);
+  const [count, setCount] = useState(180);
+  const [isFetch, setFetch] = useState(false);
+  const [isVerifiedCode, setVerifiedCode] = useState(false);
+
+  const { verificationCode, setVerificationCode } = useEmailVerifyStore(
+    (state) => state
+  );
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setCount((count) => count - 1);
+    }, 1000);
+
+    if (isVerifiedCode || count === 0) {
+      clearInterval(id);
+      if (isVerifiedCode) {
+        setIsTimeout(false);
+      } else {
+        setIsTimeout(true);
+      }
+    }
+    return () => clearInterval(id);
+  }, [count, isVerifiedCode]);
+
+  useEffect(() => {
+    if (isFetch) {
+      setCount(180);
+      setVerificationCodeInput("");
+    }
+  }, [isFetch]);
+
+  const onSubmit = async () => {
+    if (verificationCodeInput === verificationCode) {
+      setVerifiedCode(true);
+    } else {
+      toast({
+        title: "인증 코드가 일치하지 않습니다.",
+        variant: "destructive",
+        duration: 3000,
+      });
+    }
+  };
+
+  const fetchSendEmail = async () => {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/users/email?email=${email}`
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to save duration");
+    }
+
+    const result = await response.json();
+    setVerificationCode(result.result.toString());
+    setFetch(true);
+  };
+
+  return (
+    <div className="bg-gray-100 p-6 space-y-4">
+      <Input
+        disabled={count === 0 || isVerifiedCode}
+        className="py-6"
+        placeholder="인증코드 6자리"
+        value={verificationCodeInput}
+        onChange={(e) => setVerificationCodeInput(e.target.value)}
+      />
+      <div className="flex items-center flex-row justify-between">
+        <div
+          className={`text-sm text-blue-400 ${
+            count === 0 ? "text-red-400" : "text-blue-400"
+          }`}
+        >
+          {formatTime(count)}
+        </div>
+        <Button
+          onClick={onSubmit}
+          disabled={isVerifiedCode || isTimeout}
+          className="items-center justify-center bg-blue-400 hover:bg-blue-500"
+          type="button"
+        >
+          {isVerifiedCode ? "확인완료" : "확인"}
+        </Button>
+      </div>
+      <div className="flex flex-row mt-10 space-x-2 text-sm text-gray-400">
+        {!isVerifiedCode && (
+          <>
+            <p>이메일을 받지 못하셨나요?</p>
+            <p
+              onClick={fetchSendEmail}
+              className="text-gray-500 underline cursor-pointer"
+            >
+              이메일 재전송하기
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(home)/signup/lib/UserFormSchema.ts
+++ b/src/app/(home)/signup/lib/UserFormSchema.ts
@@ -41,3 +41,45 @@ export const UserFormSchema = z
     message: "비밀번호가 일치하지 않습니다.",
     path: ["passwordVerify"],
   });
+
+export const UserFormWithEmailSchema = z
+  .object({
+    name: z.string().min(2, {
+      message: "이름은 2글자 이상이어야 합니다.",
+    }),
+    email: z.string().min(1, { message: "필수 입력 항목입니다." }).email({
+      message: "이메일 형식이 올바르지 않습니다.",
+    }),
+    birthDate: z.string().min(8, {
+      message: "올바른 생년월일 8자를 입력해주세요.",
+    }),
+    password: z.string().min(8, {
+      message: "비밀번호는 영문, 숫자를 포함하여 8자 이상이어야 합니다.",
+    }),
+    passwordVerify: z.string(),
+    phoneNumber: z.string().min(10, {
+      message: "핸드폰 번호 11자리를 입력해주세요.",
+    }),
+    churchName: z.enum(["fg", "others"]),
+    departmentName: z.enum(getValues(Department), {
+      errorMap: () => ({
+        message: "부서명을 선택해주세요.",
+      }),
+    }),
+    position: z.enum(getValues(Position), {
+      errorMap: () => ({
+        message: "직분을 선택해주세요.",
+      }),
+    }),
+    yearsOfService: z.coerce
+      .number({ invalid_type_error: "숫자 형식의 값을 적어주세요." })
+      .nonnegative("0 이상의 값을 적어주세요.")
+      .lte(100, "100 이하의 값을 적어주세요."),
+    isEmailValid: z.boolean().refine((val) => val === true, {
+      message: "이메일 인증을 완료해주세요.",
+    }),
+  })
+  .refine(({ password, passwordVerify }) => password === passwordVerify, {
+    message: "비밀번호가 일치하지 않습니다.",
+    path: ["passwordVerify"],
+  });

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/components/LectureNav.tsx
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/components/LectureNav.tsx
@@ -134,7 +134,7 @@ export default function LectureNav({ courseId, lectureId }: Props) {
             <AccordionItem
               disabled={!isClickable}
               key={lecture.lectureId}
-              value={lecture.title}
+              value={lecture.lectureNumber.toString()}
             >
               <AccordionTrigger>
                 {lecture.lectureNumber}강: {lecture.title}
@@ -196,7 +196,7 @@ export default function LectureNav({ courseId, lectureId }: Props) {
                             if (
                               !(
                                 progress.lectureProgresses.find(
-                                  (lp) => lp.lectureId === lectureId
+                                  (lp) => lp.lectureId === lecture.lectureId
                                 )?.completed ||
                                 lecture.lectureNumber ===
                                   lastCompletedLectureIndex

--- a/src/app/types/next-auth.d.ts
+++ b/src/app/types/next-auth.d.ts
@@ -21,6 +21,7 @@ declare module "next-auth" {
       level: string;
       accessToken: any & DefaultSession["user"];
       enrollmentIds: number[];
+      department: string;
       error: string | undefined;
     };
     accessToken: string;

--- a/src/app/types/type.ts
+++ b/src/app/types/type.ts
@@ -74,6 +74,8 @@ export const userLevelOptions = [
   { value: "L0", label: "L0" },
   { value: "L1", label: "L1" },
   { value: "L2", label: "L2" },
+  { value: "tutor", label: "강사" },
+  { value: "manager", label: "매니저" },
 ];
 export const userLevelSettingOptions = [
   { value: "L0", label: "L0" },

--- a/src/components/ui/aspect-ratio.tsx
+++ b/src/components/ui/aspect-ratio.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio"
+
+const AspectRatio = AspectRatioPrimitive.Root
+
+export { AspectRatio }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,11 +8,26 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(`${process.env.NEXT_PUBLIC_BASE_HOST}/login`);
   }
 
-  if (
-    request.nextUrl.pathname.startsWith("/admin") &&
-    session.user.level !== "admin"
-  ) {
-    return NextResponse.redirect(`${process.env.NEXT_PUBLIC_BASE_HOST}/`);
+  if (request.nextUrl.pathname.startsWith("/admin")) {
+    if (
+      session.user.level !== "admin" &&
+      session.user.level !== "tutor" &&
+      session.user.level !== "manager"
+    ) {
+      return NextResponse.redirect(`${process.env.NEXT_PUBLIC_BASE_HOST}/`);
+    } else if (
+      session.user.level === "tutor" &&
+      request.nextUrl.pathname !== "/admin/quizzes/descriptive"
+    ) {
+      return NextResponse.redirect(
+        `${process.env.NEXT_PUBLIC_BASE_HOST}/admin/quizzes/descriptive`
+      );
+    } else if (
+      session.user.level === "manager" &&
+      request.nextUrl.pathname === "/admin/quizzes/users"
+    ) {
+      return NextResponse.redirect(`${process.env.NEXT_PUBLIC_BASE_HOST}/`);
+    }
   }
 
   const courseMatch = request.nextUrl.pathname.match(

--- a/src/store/useEmailVerifyStore.ts
+++ b/src/store/useEmailVerifyStore.ts
@@ -1,0 +1,26 @@
+// Importing create function from the Zustand library
+import { create } from "zustand";
+
+interface EmailVerifyInterface {
+  isLoading: boolean;
+  setLoading: (item: boolean) => void;
+  isVerificationSent: boolean;
+  setVerificationSent: (item: boolean) => void;
+  verificationCode: string;
+  setVerificationCode: (item: string) => void;
+  email: string;
+  setEmail: (item: string) => void;
+}
+
+const useEmailVerifyStore = create<EmailVerifyInterface>((set) => ({
+  isLoading: false,
+  setLoading: (item) => set({ isLoading: item }),
+  isVerificationSent: false,
+  setVerificationSent: (item) => set({ isVerificationSent: item }),
+  verificationCode: "",
+  setVerificationCode: (item) => set({ verificationCode: item }),
+  email: "",
+  setEmail: (item) => set({ email: item }),
+}));
+
+export default useEmailVerifyStore;


### PR DESCRIPTION
### 📟 연결된 이슈



### 👷 작업한 내용
- 관리자
    - 퀴즈 현황 타입 별 몇 개 있는지(강의 관리)**
    - 강의 컬럼 사이즈
    -  **이미지 용량 설정 or 다운 사이징(강의관리)**
    - 몇 강 중에 몇 강 들었는지 관리자 페이지(유저)
    - 강사 role 만들기
    - 남의 부서는 안 보이게
    - 퀴즈 관리만 보임
    - level에 따른 권한
    - 강의 별로 수강생 정보가 뜨게
    - 강의 별 통계
    - 코스 수정 스크롤
        - 최상위를 overflow-hidden을 해줌
- **회원가입 시 이메일**
- 코스 순서
- 퀴즈등록 스크롤바, 왼쪽 정렬
- 강의 2,3번이 같이 열림(?)
    - accordian value가 title로 되어있었음
- cascade
- 매니저 권한
    - 유저 관리 막기
    - 공지사항 올릴 수 있음
- 퀴즈등록 왼쪽정렬

### 📸 스크린샷
