### PR TITLE
fix: 클라이언트 요청 사항 반영

### DIFF
--- a/src/app/(admin)/admin/quizzes/register/components/RegisterTableColumn.tsx
+++ b/src/app/(admin)/admin/quizzes/register/components/RegisterTableColumn.tsx
@@ -41,6 +41,17 @@ export const RegisterQuizColumn: ColumnDef<AllLecturesResponse>[] = [
     enableHiding: false,
   },
   {
+    id: "quizCount",
+    accessorFn: (row) =>
+      `객${row.multipleChoiceCount}/주${row.descriptiveCount}`,
+    header: ({ column }) => {
+      return <SortingHeader column={column} title="퀴즈갯수" />;
+    },
+    cell: (info) => {
+      return <div className="text-left">{info.getValue() as string}</div>;
+    },
+  },
+  {
     id: "button",
     cell: ({ row }) => {
       const { setOpen } = useOpenDialogStore((state) => state);

--- a/src/app/(admin)/admin/videos/edit/components/CourseLectureEdit.tsx
+++ b/src/app/(admin)/admin/videos/edit/components/CourseLectureEdit.tsx
@@ -147,7 +147,7 @@ export default function CourseLectureEdit({ lecturesInfo, courseId }: Props) {
         autoComplete="off"
         autoFocus={false}
         onSubmit={form.handleSubmit(onSubmit)}
-        className="w-1/2 border overflow-y-auto border-gray-300 space-y-4 p-12 rounded-lg"
+        className="relative w-1/2 border h-full border-gray-300 space-y-4 p-12 rounded-lg"
       >
         <Button
           onClick={handleAddLecture}
@@ -155,7 +155,7 @@ export default function CourseLectureEdit({ lecturesInfo, courseId }: Props) {
         >
           강의 추가
         </Button>
-        <div className="overflow-y-auto">
+        <div className="overflow-y-auto h-4/5">
           <DragDropContext onDragEnd={onDragEnd}>
             <Droppable droppableId="droppable">
               {(droppableProvided) => (
@@ -242,7 +242,7 @@ export default function CourseLectureEdit({ lecturesInfo, courseId }: Props) {
             </Droppable>
           </DragDropContext>
         </div>
-        <Button className="w-full mt-10" type="submit">
+        <Button className="flex w-full mt-10" type="submit">
           강의 저장
         </Button>
       </form>

--- a/src/app/(home)/course/[courseId]/components/LectureList.tsx
+++ b/src/app/(home)/course/[courseId]/components/LectureList.tsx
@@ -26,6 +26,7 @@ export default function LectureList({
     <Accordion type="single" collapsible className="w-full">
       {lectures.map((ele, index) => (
         <AccordionItem
+          disabled={true}
           key={ele.lectureId}
           value={`item-${index}`}
           className="bg-blue-100 border border-blue-300 rounded-md mt-3"

--- a/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/components/LectureNav.tsx
+++ b/src/app/(lecture)/course/[courseId]/lecture/[lectureId]/components/LectureNav.tsx
@@ -32,6 +32,7 @@ type Props = {
 export default function LectureNav({ courseId, lectureId }: Props) {
   const { data: session } = useSession();
   const accessToken = session?.user.accessToken;
+  const userLevel = session?.user.level;
 
   const searchParams = useSearchParams();
   const currentQuizIndex = parseInt(searchParams.get("quizIndex") as string);
@@ -128,6 +129,9 @@ export default function LectureNav({ courseId, lectureId }: Props) {
             }
           });
           const isClickable =
+            userLevel === "admin" ||
+            userLevel === "manager" ||
+            userLevel === "tutor" ||
             lectureIds.includes(lecture.lectureId) ||
             lecture.lectureNumber === lastCompletedLectureIndex + 1 ||
             index === 0;
@@ -220,8 +224,8 @@ export default function LectureNav({ courseId, lectureId }: Props) {
                           </div>
                           <div>
                             {quiz.quizType === "multiple"
-                              ? "꼼꼼 Check! 헷갈리는 부분이 없는지 확인해보아요."
-                              : "[실행과제] 강의 내용에 대한 문제를 정확한 용어와 표현을 사용하여 설명해보세요."}
+                              ? "객관식 퀴즈"
+                              : "주관식 퀴즈"}
                           </div>
                           <div className="flex flex-row grow justify-end space-x-2">
                             <FaCircleCheck

--- a/src/hooks/useLectureQuery.ts
+++ b/src/hooks/useLectureQuery.ts
@@ -1,11 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { getAllLectures } from "./lib/getAllLectures";
-import { IQuiz } from "@/model/quiz";
-import { ILecture, ILectureTimeRecord } from "@/model/lecture";
+import { ILecture } from "@/model/lecture";
 
 export interface AllLecturesResponse extends ILecture {
-  quizzes: IQuiz[];
-  lectureTimeRecords: ILectureTimeRecord[];
+  multipleChoiceCount: number;
+  descriptiveCount: number;
 }
 
 /** [퀴즈 등록 화면 | 강의 상세 화면] 코스에 달린 강의리스트 가져오기*/


### PR DESCRIPTION
### 📟 연결된 이슈



### 👷 작업한 내용
- 2)퀴즈 등록화면에 퀴즈 갯수가 표시되어야함
- 3)강의 재생화면에서 강의/퀴즈 Accordian 바는 관리자 화면에서는 전부 보여야함
- 4)강의 재생화면에서 퀴즈 문구는 “객관식 퀴즈/주관식 퀴즈” 로 통일
- 5) 강의 상세 아코디언 막기 (들어가지 못해야 할 강의에 들어갈 수 있는 문제 때문에 제한)


### 📸 스크린샷
