### PR TITLE
🐛 fix: 퀴즈 등록 화면에 강의를 우선 배치

### DIFF
--- a/src/app/(admin)/admin/quizzes/register/components/CourseTableColumn.tsx
+++ b/src/app/(admin)/admin/quizzes/register/components/CourseTableColumn.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { formatDate } from "@/lib/utils";
+import { ColumnDef } from "@tanstack/react-table";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { Pencil } from "lucide-react";
+import { AdminCoursesResponse } from "../../../hooks/useAdminCourseQuery";
+import { SortingHeader } from "../../../components/SortingHeader";
+import useSelectedCourseIdStore from "@/store/useSelectedCourseIdStore";
+
+export const courseColumn: ColumnDef<AdminCoursesResponse>[] = [
+  {
+    accessorKey: "createdAt",
+    cell: (info) => info.getValue(),
+    enableHiding: true,
+  },
+  {
+    accessorKey: "thumbnailImagePath",
+    header: ({ column }) => {
+      return <SortingHeader column={column} title="이미지" />;
+    },
+    cell: ({ row }) => {
+      return (
+        <Image
+          className="rounded-md"
+          width={100}
+          height={100}
+          src={`${process.env.NEXT_PUBLIC_IMAGE_URL}${row.getValue(
+            "thumbnailImagePath"
+          )}`}
+          alt="강의 썸네일"
+          priority
+        />
+      );
+    },
+  },
+  {
+    accessorKey: "title",
+    header: ({ column }) => {
+      return <SortingHeader column={column} title="강의명" />;
+    },
+    cell: ({ row }) => {
+      return (
+        <div className="text-center w-full whitespace-normal break-words">
+          {row.getValue("title")}
+        </div>
+      );
+    },
+    size: 50,
+    maxSize: 50,
+  },
+  {
+    accessorKey: "enrollmentCount",
+    header: ({ column }) => {
+      return <SortingHeader column={column} title="총 수강생" />;
+    },
+    cell: ({ row }) => {
+      return (
+        <div className="text-center">{row.getValue("enrollmentCount")}</div>
+      );
+    },
+  },
+  {
+    accessorKey: "curriculum",
+    header: ({ column }) => {
+      return <SortingHeader column={column} title="카테고리" />;
+    },
+    cell: ({ row }) => {
+      return <div className="text-center">{row.getValue("curriculum")}</div>;
+    },
+  },
+  {
+    accessorKey: "status",
+    header: ({ column }) => {
+      return <SortingHeader column={column} title="상태" />;
+    },
+    cell: ({ row }) => {
+      const statusValue = row.getValue("status");
+
+      let statusLabel;
+      switch (statusValue) {
+        case "active":
+          statusLabel = "공개";
+          break;
+        case "inactive":
+          statusLabel = "비공개";
+          break;
+        case "temp":
+          statusLabel = "임시저장";
+          break;
+        default:
+          statusLabel = "알 수 없음"; // 정의되지 않은 status 값에 대한 처리
+      }
+      return <div className="text-center">{statusLabel}</div>;
+    },
+  },
+  {
+    accessorKey: "finishDate",
+    header: ({ column }) => {
+      return <SortingHeader column={column} title="마감 기한" />;
+    },
+    cell: ({ row }) => {
+      return (
+        <div className="text-center">
+          {formatDate(new Date(row.getValue("finishDate")))}
+        </div>
+      );
+    },
+  },
+  {
+    id: "quizCount",
+    accessorFn: (row) => `객${row.multipleCount}/주${row.descriptiveCount}`,
+    header: ({ column }) => {
+      return <SortingHeader column={column} title="퀴즈갯수" />;
+    },
+    cell: (info) => {
+      return <div className="text-center">{info.getValue() as string}</div>;
+    },
+  },
+  {
+    accessorKey: "courseId",
+    header: ({ column }) => {
+      return <SortingHeader column={column} title="관리" />;
+    },
+    cell: ({ row }) => {
+      const { setSelectedCourseId } = useSelectedCourseIdStore(
+        (state) => state
+      );
+      return (
+        <Button
+          onClick={() => setSelectedCourseId(row.getValue("courseId"))}
+          variant="ghost"
+          className="px-4 space-x-2 border border-gray-300 hover:bg-gray-400"
+        >
+          <Pencil className="w-4 h-4" color="blue" />
+          <div>상세보기</div>
+        </Button>
+      );
+    },
+  },
+];

--- a/src/app/(admin)/admin/quizzes/register/components/CourseTablePagination.tsx
+++ b/src/app/(admin)/admin/quizzes/register/components/CourseTablePagination.tsx
@@ -1,0 +1,109 @@
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  DoubleArrowLeftIcon,
+  DoubleArrowRightIcon,
+} from "@radix-ui/react-icons";
+import { Table } from "@tanstack/react-table";
+
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useSession } from "next-auth/react";
+import { toast } from "@/components/ui/use-toast";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+
+interface DataTablePaginationProps<TData> {
+  table: Table<TData>;
+}
+
+export function CourseTablePagination<TData>({
+  table,
+}: DataTablePaginationProps<TData>) {
+  const { data: session } = useSession();
+  const accessToken = session?.user.accessToken as string;
+
+  return (
+    <div className="flex items-center justify-between p-2">
+      <div className="flex items-center space-x-6 lg:space-x-8">
+        <div className="flex items-center space-x-2">
+          <p className="text-sm font-medium">페이지 당 행 갯수</p>
+          <Select
+            value={`${table.getState().pagination.pageSize}`}
+            onValueChange={(value) => {
+              table.setPageSize(Number(value));
+            }}
+          >
+            <SelectTrigger className="h-8 w-[70px]">
+              <SelectValue placeholder={table.getState().pagination.pageSize} />
+            </SelectTrigger>
+            <SelectContent side="top">
+              {[10, 20, 30, 40, 50].map((pageSize) => (
+                <SelectItem key={pageSize} value={`${pageSize}`}>
+                  {pageSize}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex w-[100px] items-center justify-center text-sm font-medium">
+          {table.getState().pagination.pageIndex + 1}/{table.getPageCount()}{" "}
+          페이지
+        </div>
+        <div className="flex items-center space-x-2">
+          <Button
+            variant="outline"
+            className="hidden h-8 w-8 p-0 lg:flex"
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <span className="sr-only">Go to first page</span>
+            <DoubleArrowLeftIcon className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            className="h-8 w-8 p-0"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <span className="sr-only">Go to previous page</span>
+            <ChevronLeftIcon className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            className="h-8 w-8 p-0"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            <span className="sr-only">Go to next page</span>
+            <ChevronRightIcon className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            className="hidden h-8 w-8 p-0 lg:flex"
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            disabled={!table.getCanNextPage()}
+          >
+            <span className="sr-only">Go to last page</span>
+            <DoubleArrowRightIcon className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/quizzes/register/hook/useQuizMutation.ts
+++ b/src/app/(admin)/admin/quizzes/register/hook/useQuizMutation.ts
@@ -98,10 +98,13 @@ export function useQuizMutation(
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({
-        queryKey: ["adminQuizzes"],
+        queryKey: ["courses"],
       });
       queryClient.invalidateQueries({
         queryKey: ["lectures"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["adminQuizzes"],
       });
       toast({
         title: "퀴즈 등록 완료",

--- a/src/app/(admin)/admin/quizzes/register/page.tsx
+++ b/src/app/(admin)/admin/quizzes/register/page.tsx
@@ -2,16 +2,6 @@
 
 import * as React from "react";
 
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { RegisterQuizTable } from "./components/RegisterQuizTable";
 import { RegisterQuizColumn } from "./components/RegisterTableColumn";
 import { useSession } from "next-auth/react";
@@ -19,6 +9,10 @@ import { useFetchAllLectureListQuery } from "@/hooks/useLectureQuery";
 import Loading from "@/app/(lecture)/course/[courseId]/lecture/[lectureId]/loading";
 import { useState } from "react";
 import { useFetchAllAdminCourseListQuery } from "../../hooks/useAdminCourseQuery";
+import { DataTable } from "../../videos/components/DataTable";
+import { courseColumn } from "./components/CourseTableColumn";
+import useSelectedCourseIdStore from "@/store/useSelectedCourseIdStore";
+import { Button } from "@/components/ui/button";
 
 type CourseOption = {
   courseId: number;
@@ -26,7 +20,10 @@ type CourseOption = {
 };
 
 export default function RegisterQuizPage() {
-  const [selectedCourseId, setSelectedCourseId] = useState<number | null>(null);
+  // const [selectedCourseId, setSelectedCourseId] = useState<number | null>(null);
+  const { selectedCourseId, setSelectedCourseId } = useSelectedCourseIdStore(
+    (state) => state
+  );
 
   const { data: session } = useSession();
   const accessToken = session?.user.accessToken;
@@ -40,57 +37,37 @@ export default function RegisterQuizPage() {
 
   if (!courses) return <Loading />;
 
-  const courseOptions: CourseOption[] = courses.map((course) => ({
-    courseId: course.courseId,
-    title: course.title,
-  }));
-
   return (
-    <main id="main" className="flex flex-col w-full items-start p-8">
+    <main id="main" className="flex flex-col w-full items-start p-8 space-y-4">
       <div
         id="div1"
         className="flex flex-row w-full items-start p-2 border-b-2 border-gray-300 "
       >
         <h2 className="text-2xl font-sans">퀴즈 등록 화면</h2>
       </div>
-      <div id="div2" className="flex flex-row p-2 mt-2 items-center">
-        <p className="text-base font-bold font-sans mr-4 text-center">
-          코스 선택
-        </p>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline">
-              {selectedCourseId
-                ? courseOptions.find(
-                    (option) => option.courseId === selectedCourseId
-                  )?.title
-                : "코스 선택"}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-56">
-            <DropdownMenuLabel>코스를 선택해주세요</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuRadioGroup
-              value={selectedCourseId?.toString() || ""}
-              onValueChange={(value) => setSelectedCourseId(parseInt(value))}
-            >
-              {courseOptions.map(({ courseId, title }) => (
-                <DropdownMenuRadioItem
-                  key={courseId}
-                  value={courseId.toString()}
-                >
-                  {title}
-                </DropdownMenuRadioItem>
-              ))}
-            </DropdownMenuRadioGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+      {selectedCourseId ? (
+        <div className="flex flex-row w-full justify-between p-2">
+          <div className="font-bold text-2xl">
+            {
+              courses.find((course) => course.courseId === selectedCourseId)
+                ?.title
+            }
+          </div>
+          <Button
+            disabled={selectedCourseId === null}
+            className="bg-blue-500"
+            onClick={() => setSelectedCourseId(null)}
+          >
+            코스 선택 화면
+          </Button>
+        </div>
+      ) : null}
+
       <div id="div3" className="flex flex-col w-full h-[540px] p-2">
         {lectures && selectedCourseId ? (
           <RegisterQuizTable columns={RegisterQuizColumn} data={lectures} />
         ) : (
-          <div>코스를 선택해주세요</div>
+          <DataTable columns={courseColumn} data={courses} isQuizTable={true} />
         )}
       </div>
     </main>

--- a/src/app/(admin)/admin/videos/components/DataTable.tsx
+++ b/src/app/(admin)/admin/videos/components/DataTable.tsx
@@ -33,10 +33,12 @@ import DebouncedInput from "../../users/components/DebouncedInput";
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
 import { DataTablePagination } from "./DataTablePagination";
+import { CourseTablePagination } from "../../quizzes/register/components/CourseTablePagination";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  isQuizTable?: boolean;
 }
 
 const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
@@ -52,6 +54,7 @@ const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
 export function DataTable<TData, TValue>({
   columns,
   data,
+  isQuizTable = false,
 }: DataTableProps<TData, TValue>) {
   const [globalFilter, setGlobalFilter] = useState("");
   const [sorting, setSorting] = useState<SortingState>([
@@ -61,10 +64,6 @@ export function DataTable<TData, TValue>({
     },
   ]);
   const [rowSelection, setRowSelection] = useState({});
-  // const [columnResizeMode, setColumnResizeMode] =
-  //   useState<ColumnResizeMode>("onChange");
-
-  // console.log("sdf");
 
   const router = useRouter();
 
@@ -82,7 +81,7 @@ export function DataTable<TData, TValue>({
     onRowSelectionChange: setRowSelection,
     onGlobalFilterChange: setGlobalFilter,
     columnResizeDirection: "ltr",
-    columnResizeMode: "onChange", //change column resize mode to "onChange"
+    columnResizeMode: "onChange",
     globalFilterFn: fuzzyFilter,
     initialState: {
       columnVisibility: {
@@ -94,38 +93,35 @@ export function DataTable<TData, TValue>({
       sorting,
       rowSelection,
     },
-    defaultColumn: {
-      // size: 200, //starting column size
-      // minSize: 50, //enforced during column resizing
-      // maxSize: 200,
-    },
+    defaultColumn: {},
   });
-  // console.log(table.getCenterTotalSize());
 
   return (
     <div className="flex flex-col justify-between flex-1 overflow-y-auto">
       <div className="flex flex-col justify-start overflow-y-auto">
-        <div className="relative flex items-center justify-between flex-1 w-full h-full mb-6 mr-auto md:grow-0">
-          <div>
-            <Search className="absolute z-10 w-6 h-6 top-1 left-2 text-muted-foreground" />
-            <DebouncedInput
-              value={globalFilter ?? ""}
-              onChange={(value) => setGlobalFilter(String(value))}
-              type="search"
-              placeholder="검색..."
-              className="w-full py-1 rounded-lg bg-background pl-10 md:w-[200px] lg:w-[336px] shadow border border-block"
-            />
+        {!isQuizTable && (
+          <div className="relative flex items-center justify-between flex-1 w-full h-full mb-6 mr-auto md:grow-0">
+            <div>
+              <Search className="absolute z-10 w-6 h-6 top-1 left-2 text-muted-foreground" />
+              <DebouncedInput
+                value={globalFilter ?? ""}
+                onChange={(value) => setGlobalFilter(String(value))}
+                type="search"
+                placeholder="검색..."
+                className="w-full py-1 rounded-lg bg-background pl-10 md:w-[200px] lg:w-[336px] shadow border border-block"
+              />
+            </div>
+            <Button
+              className="bg-blue-700"
+              onClick={() => {
+                router.push("/admin/videos/register");
+              }}
+            >
+              새 강의 추가
+              <Plus className="w-4 h-4 ml-2 text-white" />
+            </Button>
           </div>
-          <Button
-            className="bg-blue-700"
-            onClick={() => {
-              router.push("/admin/videos/register");
-            }}
-          >
-            새 강의 추가
-            <Plus className="w-4 h-4 ml-2 text-white" />
-          </Button>
-        </div>
+        )}
         <Table
           className={`relative container w-[${table.getCenterTotalSize()}px] justify-start mx-auto py-2 overflow-y-auto`}
         >
@@ -187,7 +183,13 @@ export function DataTable<TData, TValue>({
           </TableBody>
         </Table>
       </div>
-      <DataTablePagination table={table} />
+      {isQuizTable ? (
+        <div className="flex justify-end">
+          <CourseTablePagination table={table} />
+        </div>
+      ) : (
+        <DataTablePagination table={table} />
+      )}
     </div>
   );
 }

--- a/src/store/useSelectedCourseIdStore.ts
+++ b/src/store/useSelectedCourseIdStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface SelectedCourseIdStoreInterface {
+  selectedCourseId: number | null;
+  setSelectedCourseId: (item: number | null) => void;
+}
+
+const useSelectedCourseIdStore = create<SelectedCourseIdStoreInterface>(
+  (set) => ({
+    selectedCourseId: null,
+    setSelectedCourseId: (item) => set({ selectedCourseId: item }),
+  })
+);
+
+export default useSelectedCourseIdStore;


### PR DESCRIPTION
### 📟 연결된 이슈



### 👷 작업한 내용
- 퀴즈 등록 화면 진입 시 바로 코스 리스트가 뜨고 코스 하나를 클릭하면 강의들이 나오면서 각 강의에 퀴즈를 등록할 수 있게 함



### 📸 스크린샷
<img width="1170" alt="image" src="https://github.com/FG-Academy/FG-Academy-FE/assets/79521972/c7e50d1d-d22a-4ff2-8f6a-d6e292f623e6">
<img width="1157" alt="image" src="https://github.com/FG-Academy/FG-Academy-FE/assets/79521972/89d84ced-9274-498f-992d-1b67ec18ec12">
