### PR TITLE
fix: 퀴즈 없는 상태에서 퀴즈 추가 다이얼로그 노출

### DIFF
--- a/src/3.widgets/admin/quiz-register/ui/QuizListDialog.tsx
+++ b/src/3.widgets/admin/quiz-register/ui/QuizListDialog.tsx
@@ -67,15 +67,22 @@ export function QuizListDialog() {
       <div className="flex-1 -mx-6 px-6">
         <div className="space-y-4 pb-4">
           {quizList.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12 text-center border-2 border-dashed rounded-xl bg-muted/30">
-              <div className="bg-muted rounded-full p-4 mb-3">
-                <Plus className="w-6 h-6 text-muted-foreground" />
-              </div>
-              <h3 className="font-semibold text-lg">등록된 퀴즈가 없습니다</h3>
-              <p className="text-sm text-muted-foreground mt-1">
-                새로운 퀴즈를 추가하여 학습 경험을 향상시켜보세요.
-              </p>
-            </div>
+            <Dialog>
+              <DialogTrigger asChild>
+                <div className="flex flex-col items-center justify-center py-12 text-center border-2 border-dashed rounded-xl bg-muted/30 cursor-pointer hover:border-primary/50 hover:bg-muted/50 transition-colors">
+                  <div className="bg-muted rounded-full p-4 mb-3">
+                    <Plus className="w-6 h-6 text-muted-foreground" />
+                  </div>
+                  <h3 className="font-semibold text-lg">등록된 퀴즈가 없습니다</h3>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    새로운 퀴즈를 추가하여 학습 경험을 향상시켜보세요.
+                  </p>
+                </div>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-[600px] p-0 overflow-hidden gap-0">
+                <QuizForm mode="create" lectureId={lectureId} />
+              </DialogContent>
+            </Dialog>
           ) : (
             quizList.map((quiz, index) => (
               <Card


### PR DESCRIPTION
## 변경사항

빈 퀴즈 목록 상태에서 퀴즈 추가 Dialog가 노출되지 않던 문제를 수정했습니다.

### 수정 내용
- `QuizListDialog.tsx`에서 퀴즈가 없는 빈 상태에 Dialog와 DialogTrigger를 연결
- 사용자가 "등록된 퀴즈가 없습니다" 화면을 클릭하면 퀴즈 추가 폼이 노출됨

### 관련 파일
- 

--- 

PR 생성 일시: 2026-01-22